### PR TITLE
Add external Postgres configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,23 @@ helm install my-n8n ./n8n
 ```
 
 You can customise the deployment by editing the values in `n8n/values.yaml` or by supplying your own values file.
+
+## Connecting to an external PostgreSQL database
+
+To use an external database instead of the default SQLite storage you can
+provide the connection details in `values.yaml`:
+
+```yaml
+database:
+  host: postgres.example.com
+  port: 5432
+  user: n8n
+  password: mysecret
+
+# Additional environment variables required by n8n
+extraEnv:
+  - name: DB_TYPE
+    value: postgresdb
+  - name: DB_POSTGRESDB_DATABASE
+    value: n8n
+```

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -44,9 +44,28 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          {{- with .Values.extraEnv }}
+          {{- $db := .Values.database }}
+          {{- if or $db.host $db.port $db.user $db.password (gt (len .Values.extraEnv) 0) }}
           env:
+            {{- if $db.host }}
+            - name: DB_POSTGRESDB_HOST
+              value: "{{ $db.host }}"
+            {{- end }}
+            {{- if $db.port }}
+            - name: DB_POSTGRESDB_PORT
+              value: "{{ $db.port }}"
+            {{- end }}
+            {{- if $db.user }}
+            - name: DB_POSTGRESDB_USER
+              value: "{{ $db.user }}"
+            {{- end }}
+            {{- if $db.password }}
+            - name: DB_POSTGRESDB_PASSWORD
+              value: "{{ $db.password }}"
+            {{- end }}
+            {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -54,6 +54,14 @@ extraEnv: []
 # - name: N8N_BASIC_AUTH_ACTIVE
 #   value: "true"
 
+# Connection details for an external PostgreSQL database. Leave values empty to
+# use the built-in SQLite storage.
+database:
+  host: ""
+  port: 5432
+  user: ""
+  password: ""
+
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types


### PR DESCRIPTION
## Summary
- allow configuring an external PostgreSQL database via `database` values
- template deployment to pass DB connection variables when provided
- document how to connect to PostgreSQL in README
- bump chart version to 0.1.1

## Testing
- `helm lint n8n`

------
https://chatgpt.com/codex/tasks/task_e_684be0cd2ea8832a830d8bbf67728f0d