### PR TITLE
Add Helm lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+      - name: Helm lint
+        run: helm lint n8n
+      - name: Helm template
+        run: helm template n8n
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # n8n Helm Chart
+[![Lint](https://github.com/n8n-io/n8n-helm/actions/workflows/lint.yaml/badge.svg)](https://github.com/n8n-io/n8n-helm/actions/workflows/lint.yaml)
+
 
 This repository contains a Kubernetes Helm chart for deploying [n8n](https://github.com/n8n-io/n8n), an extendable workflow automation tool. The chart is located in the `n8n/` directory.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint helm chart and render templates
- show workflow badge in README

## Testing
- `helm lint n8n`
- `helm template n8n`


------
https://chatgpt.com/codex/tasks/task_e_684be0c64490832abb0689fcd5d928fb