### PR TITLE
Add envFrom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,21 @@ helm install my-n8n ./n8n
 ```
 
 You can customise the deployment by editing the values in `n8n/values.yaml` or by supplying your own values file.
+
+### Example: Mounting credentials from a Secret
+
+Create a secret containing the desired environment variables:
+
+```bash
+kubectl create secret generic n8n-secret \
+  --from-literal=N8N_BASIC_AUTH_USER=user \
+  --from-literal=N8N_BASIC_AUTH_PASSWORD=pass
+```
+
+Then reference the secret using `extraEnvFrom` in your values file:
+
+```yaml
+extraEnvFrom:
+  - secretRef:
+      name: n8n-secret
+```

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.extraEnv }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -54,6 +54,11 @@ extraEnv: []
 # - name: N8N_BASIC_AUTH_ACTIVE
 #   value: "true"
 
+# Additional sources for environment variables
+extraEnvFrom: []
+# - secretRef:
+#     name: n8n-secret
+
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types


### PR DESCRIPTION
## Summary
- add an `extraEnvFrom` list to `values.yaml`
- surface `extraEnvFrom` in the deployment template
- document how to mount a secret using `extraEnvFrom`

## Testing
- `helm lint n8n` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684be0c318d8832ab27a7bd87fe8aea6