### PR TITLE
Add persistence support to Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ helm install my-n8n ./n8n
 ```
 
 You can customise the deployment by editing the values in `n8n/values.yaml` or by supplying your own values file.
+
+## Persistence
+
+Set `persistence.enabled` to `true` to store workflows and other n8n data on a persistent volume. The claim size and storage class can be adjusted with the `size` and `storageClass` values. Data is mounted at `/home/node/.n8n` inside the pod.
+
+```yaml
+persistence:
+  enabled: true
+  size: 8Gi
+  storageClass: standard
+```

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -60,13 +60,32 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /home/node/.n8n
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- else }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- end }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "n8n.fullname" . }}-data
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- else }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/n8n/templates/pvc.yaml
+++ b/n8n/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "n8n.fullname" . }}-data
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -108,6 +108,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+persistence:
+  enabled: false
+  size: 8Gi
+  storageClass: ""
+
 # Additional volumes on the output Deployment definition.
 volumes: []
 # - name: foo


### PR DESCRIPTION
## Summary
- add persistence section to `values.yaml`
- mount persistent volume in deployment when enabled
- create PersistentVolumeClaim template
- document persistence options in README

## Testing
- `helm lint ./n8n`
- `helm template test ./n8n --set persistence.enabled=true`

------
https://chatgpt.com/codex/tasks/task_e_684be0c1b1c4832aa84226650960a4af