### PR TITLE
Fix README customization instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ helm repo update
 helm install my-n8n n8n/n8n
 ```
 
-
 Customise the deployment by editing the values in `n8n/values.yaml` or by supplying your own values file.
 
 ### Example value overrides


### PR DESCRIPTION
## Summary
- remove leftover blank line after installation instructions
- keep single customization sentence for clarity

## Testing
- `grep -ni customise README.md`

------
https://chatgpt.com/codex/tasks/task_e_684c1b1f3144832a96611eab99a0a812