### PR TITLE
Add DB database name config

### DIFF
--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           {{- $db := .Values.database }}
-          {{- if or $db.host $db.port $db.user $db.password (gt (len .Values.extraEnv) 0) }}
+          {{- if or $db.host $db.port $db.user $db.password $db.database (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if $db.host }}
             - name: DB_POSTGRESDB_HOST
@@ -62,6 +62,10 @@ spec:
             {{- if $db.password }}
             - name: DB_POSTGRESDB_PASSWORD
               value: "{{ $db.password }}"
+            {{- end }}
+            {{- if $db.database }}
+            - name: DB_POSTGRESDB_DATABASE
+              value: "{{ $db.database }}"
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -65,6 +65,17 @@
         "additionalProperties": false
       }
     },
+    "database": {
+      "type": "object",
+      "properties": {
+        "host": { "type": "string" },
+        "port": { "type": "integer" },
+        "user": { "type": "string" },
+        "password": { "type": "string" },
+        "database": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
     "service": {
       "type": "object",
       "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -61,6 +61,7 @@ database:
   port: 5432
   user: ""
   password: ""
+  database: ""
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:


### PR DESCRIPTION
## Summary
- add database name field to values.yaml
- template DB_POSTGRESDB_DATABASE when configured
- validate database fields in values.schema.json

## Testing
- `helm lint n8n` *(fails: Additional property persistence is not allowed)*
- `helm template n8n` *(fails: Additional property persistence is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_684c1cf34d34832a8011c14ed13ce686