### PR TITLE
Add helm unittest to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,8 +10,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Helm
         uses: azure/setup-helm@v3
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
       - name: Helm lint
         run: helm lint n8n
+      - name: Helm unit tests
+        run: helm unittest n8n
       - name: Helm template
         run: helm template n8n
 

--- a/n8n/tests/deployment_test.yaml
+++ b/n8n/tests/deployment_test.yaml
@@ -1,0 +1,9 @@
+suite: deployment defaults
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: sets replica count to 1 by default
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1

--- a/n8n/tests/service_test.yaml
+++ b/n8n/tests/service_test.yaml
@@ -1,0 +1,9 @@
+suite: service defaults
+templates:
+  - templates/service.yaml
+tests:
+  - it: renders a ClusterIP service by default
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP


### PR DESCRIPTION
## Summary
- run helm unittest in CI
- add minimal service and deployment tests

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_684c4bc799b8832ab50887c7ba0b3873