### PR TITLE
Add secret ref for database password

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ directly to the connection fields:
 - `database.port` – listening port
 - `database.user` – database user name
 - `database.password` – user password
+- `database.passwordSecret.name` – name of a secret containing the password
+- `database.passwordSecret.key` – key within the secret (defaults to `password`)
 - `database.database` – name of the database to connect to
 
 n8n also requires the following environment variables:
@@ -135,7 +137,10 @@ database:
   host: postgres.example.com
   port: 5432
   user: n8n
-  password: mysecret
+  # password: mysecret
+  passwordSecret:
+    name: n8n-db
+    key: password
   database: n8n
 
 extraEnv:
@@ -152,7 +157,8 @@ helm install my-n8n n8n/n8n \
   --set database.host=postgres.example.com \
   --set database.port=5432 \
   --set database.user=n8n \
-  --set database.password=mysecret \
+  --set database.passwordSecret.name=n8n-db \
+  --set database.passwordSecret.key=password \
   --set database.database=n8n \
   --set extraEnv[0].name=DB_TYPE \
   --set extraEnv[0].value=postgresdb \

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -45,7 +45,8 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           {{- $db := .Values.database }}
-          {{- if or $db.host $db.port $db.user $db.password $db.database (gt (len .Values.extraEnv) 0) }}
+          {{- $secret := $db.passwordSecret }}
+          {{- if or $db.host $db.port $db.user $db.password $secret.name $db.database (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if $db.host }}
             - name: DB_POSTGRESDB_HOST
@@ -62,6 +63,12 @@ spec:
             {{- if $db.password }}
             - name: DB_POSTGRESDB_PASSWORD
               value: "{{ $db.password }}"
+            {{- else if $secret.name }}
+            - name: DB_POSTGRESDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret.name }}
+                  key: {{ $secret.key | default "password" }}
             {{- end }}
             {{- if $db.database }}
             - name: DB_POSTGRESDB_DATABASE

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -72,6 +72,14 @@
         "port": { "type": "integer" },
         "user": { "type": "string" },
         "password": { "type": "string" },
+        "passwordSecret": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
         "database": { "type": "string" }
       },
       "additionalProperties": false

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -61,6 +61,10 @@ database:
   port: 5432
   user: ""
   password: ""
+  # Reference an existing secret for the password instead of setting it directly
+  passwordSecret:
+    name: ""
+    key: "password"
   database: ""
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/


### PR DESCRIPTION
## Summary
- add ability to reference a secret for `database.password`
- update deployment to source password from the secret
- document new values in the README
- bump Chart version

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684c63f4d0bc832a900c7a39910f97f5