### PR TITLE
Enable non-root security defaults

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -25,6 +25,13 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 
 See `values.yaml` for all available settings.
 
+## Security
+
+By default the chart runs the n8n container as a non-root user and mounts the
+root filesystem as read-only with privilege escalation disabled. These settings
+are defined in `podSecurityContext` and `securityContext` in `values.yaml` and
+can be adjusted if needed.
+
 ## Updating n8n versions
 
 When a new n8n release is published, bump the `appVersion` field in

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -28,16 +28,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -38,16 +38,17 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsUser: 1000
+  fsGroup: 1000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 # Additional environment variables for the n8n container
 extraEnv: []


### PR DESCRIPTION
## Summary
- run the n8n container as non-root and enforce a read-only rootfs by default
- apply pod security settings unconditionally in the deployment template
- document security defaults in the chart README

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684c652be560832a853b561086a29686