### PR TITLE
Add configurable NetworkPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,31 @@ helm install my-n8n n8n/n8n \
 
 The chart also includes a `values.schema.json` file that defines the allowed structure of `values.yaml`. Helm uses this schema to validate any custom values supplied during installation or upgrades.
 
+## Network policies
+
+Set `networkPolicy.enabled` to `true` to create a `NetworkPolicy` resource that denies all traffic by default. Custom ingress and egress rules can be added under `networkPolicy.ingress` and `networkPolicy.egress`.
+
+Example enabling the policy from the command line:
+
+```bash
+helm install my-n8n n8n/n8n \
+  --set networkPolicy.enabled=true
+```
+
+To allow specific traffic, extend the policy in your values file:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 5678
+  egress: []
+```
+
 ## Connecting to an external PostgreSQL database
 
 To use an external PostgreSQL server instead of the built in SQLite

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -20,6 +20,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **image.tag** – n8n container image tag to deploy.
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume.
+- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **extraEnv** – additional environment variables passed to the container.
 

--- a/n8n/templates/networkpolicy.yaml
+++ b/n8n/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "n8n.fullname" . }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "n8n.selectorLabels" . | nindent 6 }}
+  policyTypes:
+{{- range .Values.networkPolicy.policyTypes }}
+    - {{ . }}
+{{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- else }}
+  ingress: []
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- else }}
+  egress: []
+  {{- end }}
+{{- end }}

--- a/n8n/tests/networkpolicy_test.yaml
+++ b/n8n/tests/networkpolicy_test.yaml
@@ -1,0 +1,22 @@
+suite: network policy
+templates:
+  - templates/networkpolicy.yaml
+tests:
+  - it: is not rendered when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates policy when enabled
+    set:
+      networkPolicy:
+        enabled: true
+    asserts:
+      - equal:
+          path: kind
+          value: NetworkPolicy
+      - equal:
+          path: spec.ingress
+          value: []
+      - equal:
+          path: spec.egress
+          value: []

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -139,6 +139,19 @@
       },
       "additionalProperties": false
     },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "policyTypes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "ingress": { "type": "array", "items": { "type": "object" } },
+        "egress": { "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": false
+    },
     "resources": { "type": "object" },
     "livenessProbe": { "type": "object" },
     "readinessProbe": { "type": "object" },

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -92,6 +92,14 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+networkPolicy:
+  enabled: false
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Summary
- add `networkPolicy` template and values
- bump chart version
- document NetworkPolicy usage
- add unittest for new template

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684c66214f04832abb6c459753f7580b