### PR TITLE
Add optional RBAC resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ networkPolicy:
   egress: []
 ```
 
+## Role-based access control
+
+Enable creation of a Role and RoleBinding for the service account by setting `rbac.create`:
+
+```bash
+helm install my-n8n n8n/n8n \
+  --set rbac.create=true
+```
+
 ## Connecting to an external PostgreSQL database
 
 To use an external PostgreSQL server instead of the built in SQLite

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -21,6 +21,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume.
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic.
+- **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **extraEnv** – additional environment variables passed to the container.
 

--- a/n8n/templates/role.yaml
+++ b/n8n/templates/role.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "n8n.fullname" . }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/n8n/templates/rolebinding.yaml
+++ b/n8n/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "n8n.fullname" . }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "n8n.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "n8n.fullname" . }}
+{{- end }}

--- a/n8n/tests/rbac_test.yaml
+++ b/n8n/tests/rbac_test.yaml
@@ -1,0 +1,25 @@
+suite: rbac
+templates:
+  - templates/role.yaml
+  - templates/rolebinding.yaml
+tests:
+  - it: is not rendered when disabled
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates Role and RoleBinding when enabled
+    set:
+      rbac:
+        create: true
+    asserts:
+      - equal:
+          path: kind
+          value: Role
+        template: templates/role.yaml
+      - equal:
+          path: kind
+          value: RoleBinding
+        template: templates/rolebinding.yaml

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -43,6 +43,13 @@
       },
       "additionalProperties": false
     },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
     "podAnnotations": {
       "type": "object",
       "additionalProperties": { "type": "string" }

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -31,6 +31,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# Toggle creation of Role and RoleBinding resources
+rbac:
+  create: false
+
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}


### PR DESCRIPTION
## Summary
- add Role and RoleBinding templates
- allow toggling their creation via `rbac.create`
- document how to enable RBAC
- bump chart version

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684c67d04e68832aa37775df1dc3e307