### PR TITLE
Add PodDisruptionBudget option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ networkPolicy:
   egress: []
 ```
 
+## Pod disruption budgets
+
+Create a PodDisruptionBudget to control the number of pods that may be
+voluntarily evicted at once. Enable the budget and specify either
+`pdb.minAvailable` or `pdb.maxUnavailable`:
+
+```bash
+helm install my-n8n n8n/n8n \
+  --set pdb.enabled=true \
+  --set pdb.minAvailable=1
+```
+
+
 ## Role-based access control
 
 Enable creation of a Role and RoleBinding for the service account by setting `rbac.create`:

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -21,6 +21,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume.
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic.
+- **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **extraEnv** – additional environment variables passed to the container.

--- a/n8n/templates/pdb.yaml
+++ b/n8n/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "n8n.fullname" . }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "n8n.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/n8n/tests/pdb_test.yaml
+++ b/n8n/tests/pdb_test.yaml
@@ -1,0 +1,26 @@
+suite: pdb
+templates:
+  - templates/pdb.yaml
+tests:
+  - it: is not rendered when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: sets minAvailable when configured
+    set:
+      pdb:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1
+  - it: sets maxUnavailable when configured
+    set:
+      pdb:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -173,6 +173,15 @@
       },
       "additionalProperties": false
     },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] },
+        "maxUnavailable": { "type": ["integer", "string"] }
+      },
+      "additionalProperties": false
+    },
     "persistence": {
       "type": "object",
       "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -134,6 +134,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+pdb:
+  enabled: false
+  # minAvailable: 1
+  # maxUnavailable: 0
+
 persistence:
   enabled: false
   size: 8Gi


### PR DESCRIPTION
## Summary
- add PodDisruptionBudget template and tests
- expose pdb.enabled options in values and schema
- document PDB configuration
- bump chart version

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684c6a0fb044832a8acebc4467b61fab