### PR TITLE
Add resource defaults and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ helm install my-n8n n8n/n8n \
   --set rbac.create=true
 ```
 
+## CPU and memory
+
+The chart sets conservative resource requests and limits. For production
+deployments edit the values under the `resources` block in `values.yaml` or
+override them on the command line:
+
+```bash
+helm install my-n8n n8n/n8n \
+  --set resources.requests.cpu=500m \
+  --set resources.requests.memory=512Mi \
+  --set resources.limits.cpu=1 \
+  --set resources.limits.memory=1Gi
+```
+
 ## Connecting to an external PostgreSQL database
 
 To use an external PostgreSQL server instead of the built in SQLite

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -25,6 +25,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **extraEnv** – additional environment variables passed to the container.
+- **resources** – CPU and memory requests/limits. Defaults are conservative and
+  should be tuned for production installations.
 
 See `values.yaml` for all available settings.
 
@@ -39,3 +41,18 @@ can be adjusted if needed.
 
 When a new n8n release is published, bump the `appVersion` field in
 `Chart.yaml` and update the default `image.tag` in `values.yaml` to match.
+
+## CPU and memory settings
+
+The chart ships with minimal resource requests and limits suitable for test
+deployments. For production workloads increase the values under the
+`resources` block in your `values.yaml` file or via command line flags. For
+example:
+
+```bash
+helm install my-n8n n8n/n8n \
+  --set resources.requests.cpu=500m \
+  --set resources.requests.memory=512Mi \
+  --set resources.limits.cpu=1 \
+  --set resources.limits.memory=1Gi
+```

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -104,17 +104,15 @@ networkPolicy:
   ingress: []
   egress: []
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  # Conservative defaults suitable for small test environments. Adjust
+  # the CPU and memory values for production workloads.
+  limits:
+    cpu: 250m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:


### PR DESCRIPTION
## Summary
- set default CPU/memory requests and limits
- describe how to override them for production in the chart docs
- mention production tuning in repository README

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684c6c2d2298832aacca4eaced40e554