### PR TITLE
Add encryption key secret option

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,30 @@ helm install my-n8n n8n/n8n \
   --set extraEnv[1].name=DB_POSTGRESDB_DATABASE \
   --set extraEnv[1].value=n8n
 ```
+
+## Credential encryption
+
+Generate a 256‑bit key and store it in a secret to encrypt credentials:
+
+```bash
+kubectl create secret generic n8n-key \
+  --from-literal=encryptionKey=$(openssl rand -hex 32)
+```
+
+Reference the secret in your values:
+
+```yaml
+encryptionKeySecret:
+  name: n8n-key
+  key: encryptionKey
+```
+
+Or set it on the command line:
+
+```bash
+helm install my-n8n n8n/n8n \
+  --set encryptionKeySecret.name=n8n-key
+```
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -24,6 +24,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
+- **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
 - **extraEnv** – additional environment variables passed to the container.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -42,7 +42,8 @@ spec:
               protocol: TCP
           {{- $db := .Values.database }}
           {{- $secret := $db.passwordSecret }}
-          {{- if or $db.host $db.port $db.user $db.password $secret.name $db.database (gt (len .Values.extraEnv) 0) }}
+          {{- $enc := .Values.encryptionKeySecret }}
+          {{- if or $db.host $db.port $db.user $db.password $secret.name $db.database $enc.name (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if $db.host }}
             - name: DB_POSTGRESDB_HOST
@@ -69,6 +70,13 @@ spec:
             {{- if $db.database }}
             - name: DB_POSTGRESDB_DATABASE
               value: "{{ $db.database }}"
+            {{- end }}
+            {{- if $enc.name }}
+            - name: N8N_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $enc.name }}
+                  key: {{ $enc.key | default "encryptionKey" }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -91,6 +91,14 @@
       },
       "additionalProperties": false
     },
+    "encryptionKeySecret": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "key": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
     "service": {
       "type": "object",
       "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -72,6 +72,11 @@ database:
     key: "password"
   database: ""
 
+# Reference a secret containing the N8N_ENCRYPTION_KEY value
+encryptionKeySecret:
+  name: ""
+  key: encryptionKey
+
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types


### PR DESCRIPTION
## Summary
- add `encryptionKeySecret` value to reference a Kubernetes secret
- expose `N8N_ENCRYPTION_KEY` in deployment when secret is set
- document how to generate and supply the key
- bump chart version to 0.1.6

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`
- `helm template my-n8n n8n --set encryptionKeySecret.name=mykey`

------
https://chatgpt.com/codex/tasks/task_e_684c6d69d924832a9c9c9d7ab9f70551