### PR TITLE
Add configurable secret and configmap mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,30 @@ Or set it on the command line:
 helm install my-n8n n8n/n8n \
   --set encryptionKeySecret.name=n8n-key
 ```
+
+## Mounting additional Secrets and ConfigMaps
+
+Existing Kubernetes resources can be mounted using the `extraSecrets` and
+`extraConfigMaps` values:
+
+```yaml
+extraSecrets:
+  - name: my-secret
+    mountPath: /etc/secret
+extraConfigMaps:
+  - name: my-config
+    mountPath: /etc/config
+```
+
+Install with command line flags:
+
+```bash
+helm install my-n8n n8n/n8n \
+  --set extraSecrets[0].name=my-secret \
+  --set extraSecrets[0].mountPath=/etc/secret \
+  --set extraConfigMaps[0].name=my-config \
+  --set extraConfigMaps[0].mountPath=/etc/config
+```
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -26,6 +26,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
 - **extraEnv** – additional environment variables passed to the container.
+- **extraSecrets** – mount additional Secrets inside the pod.
+- **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
 

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -101,10 +101,33 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- range .Values.extraSecrets }}
+            - name: secret-{{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly | default true }}
+            {{- end }}
+            {{- range .Values.extraConfigMaps }}
+            - name: config-{{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly | default true }}
+            {{- end }}
           {{- else }}
-          {{- with .Values.volumeMounts }}
+          {{- $vm := .Values.volumeMounts }}
+          {{- if or (gt (len $vm) 0) (gt (len .Values.extraSecrets) 0) (gt (len .Values.extraConfigMaps) 0) }}
           volumeMounts:
+            {{- with $vm }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- range .Values.extraSecrets }}
+            - name: secret-{{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly | default true }}
+            {{- end }}
+            {{- range .Values.extraConfigMaps }}
+            - name: config-{{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly | default true }}
+            {{- end }}
           {{- end }}
           {{- end }}
       {{- if .Values.persistence.enabled }}
@@ -115,10 +138,33 @@ spec:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- range .Values.extraSecrets }}
+        - name: secret-{{ .name }}
+          secret:
+            secretName: {{ .name }}
+        {{- end }}
+        {{- range .Values.extraConfigMaps }}
+        - name: config-{{ .name }}
+          configMap:
+            name: {{ .name }}
+        {{- end }}
       {{- else }}
-      {{- with .Values.volumes }}
+      {{- $vol := .Values.volumes }}
+      {{- if or (gt (len $vol) 0) (gt (len .Values.extraSecrets) 0) (gt (len .Values.extraConfigMaps) 0) }}
       volumes:
+        {{- with $vol }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- range .Values.extraSecrets }}
+        - name: secret-{{ .name }}
+          secret:
+            secretName: {{ .name }}
+        {{- end }}
+        {{- range .Values.extraConfigMaps }}
+        - name: config-{{ .name }}
+          configMap:
+            name: {{ .name }}
+        {{- end }}
       {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -201,6 +201,32 @@
     },
     "volumes": { "type": "array", "items": { "type": "object" } },
     "volumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "mountPath": { "type": "string" },
+          "readOnly": { "type": "boolean" }
+        },
+        "required": ["name", "mountPath"],
+        "additionalProperties": false
+      }
+    },
+    "extraConfigMaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "mountPath": { "type": "string" },
+          "readOnly": { "type": "boolean" }
+        },
+        "required": ["name", "mountPath"],
+        "additionalProperties": false
+      }
+    },
     "nodeSelector": {
       "type": "object",
       "additionalProperties": { "type": "string" }

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -160,6 +160,16 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# Mount additional Kubernetes Secrets as volumes.
+extraSecrets: []
+# - name: my-secret
+#   mountPath: /etc/secret
+
+# Mount additional ConfigMaps as volumes.
+extraConfigMaps: []
+# - name: my-config
+#   mountPath: /etc/config
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Summary
- allow mounting extra secrets and config maps via Helm values
- mount these resources as additional volumes in the deployment
- document the new values with examples
- bump chart version to 0.1.7

## Testing
- `helm lint n8n`
- `helm unittest n8n`


------
https://chatgpt.com/codex/tasks/task_e_684c73836124832a9646211380acd571