### PR TITLE
Update lint workflow triggers

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,12 @@
 name: Lint
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- run lint on pushes to `main`
- add a nightly lint schedule

## Testing
- `helm lint n8n` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d16a32b24832aa689f97325c43a1b