### PR TITLE
Add chart release workflow and docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:

--- a/README.md
+++ b/README.md
@@ -276,7 +276,13 @@ helm install my-n8n n8n/n8n \
 ```
 ## Publishing
 
-Chart packages are published to the `gh-pages` branch by GitHub Actions. The [`release.yaml`](.github/workflows/release.yaml) workflow packages the chart from the `n8n` directory on every push to `main` and updates the repository index hosted at <https://anyfavors.github.io/n8n-helm>.
+Chart releases are handled automatically by [chart-releaser](https://github.com/helm/chart-releaser).
+To publish a new version:
+
+1. Update the `version` (and optionally `appVersion`) fields in `n8n/Chart.yaml`.
+2. Commit the change to the `main` branch.
+3. Push the commit to GitHub. The [`release.yaml`](.github/workflows/release.yaml) workflow packages the chart from the `n8n` directory and uploads it to a GitHub release.
+4. Once the workflow completes, the repository index on the `gh-pages` branch is updated at <https://anyfavors.github.io/n8n-helm>.
 
 ## License
 

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -64,5 +64,7 @@ helm install my-n8n n8n/n8n \
 
 ## Publishing
 
-This chart is packaged and released to the `gh-pages` branch by [GitHub Actions](../.github/workflows/release.yaml) when changes are pushed to `main`. Users can add <https://anyfavors.github.io/n8n-helm> as a Helm repository to install published versions.
+Chart packages are created automatically using [chart-releaser](https://github.com/helm/chart-releaser) when commits land on `main`.
+To cut a release, bump the version in `Chart.yaml` and push the change. The [`release.yaml`](../.github/workflows/release.yaml) workflow will upload the packaged chart to GitHub and update the index on `gh-pages`.
+Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository to install published versions.
 


### PR DESCRIPTION
## Summary
- release charts automatically with chart-releaser
- document release process in README files

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684d17c76874832a83d19a359beff214