### PR TITLE
Improve validation schemas

### DIFF
--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -58,8 +58,33 @@
       "type": "object",
       "additionalProperties": { "type": "string" }
     },
-    "podSecurityContext": { "type": "object" },
-    "securityContext": { "type": "object" },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "runAsUser": { "type": "integer" },
+        "fsGroup": { "type": "integer" }
+      },
+      "additionalProperties": false
+    },
+    "securityContext": {
+      "type": "object",
+      "properties": {
+        "runAsNonRoot": { "type": "boolean" },
+        "readOnlyRootFilesystem": { "type": "boolean" },
+        "allowPrivilegeEscalation": { "type": "boolean" },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "extraEnv": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## Summary
- define stricter schemas for `securityContext` and `podSecurityContext`
- regenerate schema annotations

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`


------
https://chatgpt.com/codex/tasks/task_e_684d5182852c832abbbc30505bfd71fa