### PR TITLE
Add existing claim option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ ingress:
 ```
 ## Persistence
 
-Set `persistence.enabled` to `true` to store workflows and other n8n data on a persistent volume. The claim size and storage class can be adjusted with the `size` and `storageClass` values. Data is mounted at `/home/node/.n8n` inside the pod.
+Set `persistence.enabled` to `true` to store workflows and other n8n data on a persistent volume. The claim size and storage class can be adjusted with the `size` and `storageClass` values, or supply `existingClaim` to mount a pre-created PersistentVolumeClaim. Data is mounted at `/home/node/.n8n` inside the pod.
 
 ```yaml
 persistence:
   enabled: true
   size: 8Gi
   storageClass: standard
+  existingClaim: my-data
 ```
 
 Install with these settings from the command line:

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -22,6 +22,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **image.tag** – n8n container image tag to deploy.
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume.
+- **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic.
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -134,7 +134,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "n8n.fullname" . }}-data
+            claimName: {{ default (printf "%s-data" (include "n8n.fullname" .)) .Values.persistence.existingClaim }}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/n8n/templates/pvc.yaml
+++ b/n8n/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/n8n/tests/deployment_test.yaml
+++ b/n8n/tests/deployment_test.yaml
@@ -7,3 +7,12 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
+  - it: mounts existing pvc when configured
+    set:
+      persistence:
+        enabled: true
+        existingClaim: my-data
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: my-data

--- a/n8n/tests/persistence_test.yaml
+++ b/n8n/tests/persistence_test.yaml
@@ -19,3 +19,11 @@ tests:
       - equal:
           path: spec.resources.requests.storage
           value: 5Gi
+  - it: skips creation when existing claim is provided
+    set:
+      persistence:
+        enabled: true
+        existingClaim: my-data
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -220,7 +220,8 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "size": { "type": "string" },
-        "storageClass": { "type": "string" }
+        "storageClass": { "type": "string" },
+        "existingClaim": { "type": "string" }
       },
       "additionalProperties": false
     },

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -146,6 +146,7 @@ persistence:
   enabled: false
   size: 8Gi
   storageClass: ""
+  existingClaim: ""
 
 # Additional volumes on the output Deployment definition.
 volumes: []


### PR DESCRIPTION
## Summary
- allow specifying an existing `PersistentVolumeClaim`
- document the new option in README files
- use the claim in Deployment when configured
- skip PVC creation when using existing claim
- bump chart version
- extend helm-unittest coverage

## Testing
- `helm lint n8n`
- `helm unittest n8n`


------
https://chatgpt.com/codex/tasks/task_e_684d5fe5db78832aaeb17dfae84d574c