### PR TITLE
Add service annotations support

### DIFF
--- a/n8n/templates/service.yaml
+++ b/n8n/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/n8n/tests/service_test.yaml
+++ b/n8n/tests/service_test.yaml
@@ -7,3 +7,12 @@ tests:
       - equal:
           path: spec.type
           value: ClusterIP
+  - it: injects annotations when provided
+    set:
+      service:
+        annotations:
+          foo: bar
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: bar

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -128,7 +128,11 @@
       "type": "object",
       "properties": {
         "type": { "type": "string" },
-        "port": { "type": "integer" }
+        "port": { "type": "integer" },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
       },
       "additionalProperties": false
     },

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -83,6 +83,8 @@ service:
   type: ClusterIP
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 5678
+  # Annotations to add to the service
+  annotations: {}
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:


### PR DESCRIPTION
## Summary
- allow adding annotations to the Service
- document service.annotations in the schema and defaults
- render annotations in the Service manifest
- test annotation injection in unit tests

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684d7c0fcf28832ab265cdf33b2512a0