### PR TITLE
Add NodePort/LoadBalancer service tests

### DIFF
--- a/n8n/tests/service_test.yaml
+++ b/n8n/tests/service_test.yaml
@@ -16,3 +16,21 @@ tests:
       - equal:
           path: metadata.annotations.foo
           value: bar
+  - it: renders a NodePort service when configured
+    set:
+      service:
+        type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - notExists:
+          path: spec.ports[0].nodePort
+  - it: renders a LoadBalancer service when configured
+    set:
+      service:
+        type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer


### PR DESCRIPTION
## Summary
- cover NodePort and LoadBalancer service types in unit tests

## Testing
- `helm lint n8n`
- `helm unittest n8n`
- `helm template n8n`


------
https://chatgpt.com/codex/tasks/task_e_684d8578f2e4832a9f180ba8fa17c5b1