### PR TITLE
Add Trivy vulnerability scan to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,4 +23,11 @@ jobs:
         run: helm unittest n8n
       - name: Helm template
         run: helm template n8n
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@v0.14.0
+        with:
+          scan-type: fs
+          scan-ref: n8n
+          exit-code: 1
+          severity: HIGH
 


### PR DESCRIPTION
## Summary
- run Trivy after helm tests in GitHub Actions
- fail the job on high severity vulnerabilities

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d888f9b90832ab5261f7c83147ae4