### PR TITLE
Disable service account automount

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -44,6 +44,10 @@ root filesystem as read-only with privilege escalation disabled. These settings
 are defined in `podSecurityContext` and `securityContext` in `values.yaml` and
 can be adjusted if needed.
 
+Automatic mounting of the ServiceAccount token is disabled via
+`serviceAccount.automount` to limit access to the Kubernetes API and reduce the
+attack surface.
+
 ## Updating n8n versions
 
 When a new n8n release is published, bump the `appVersion` field in
@@ -137,7 +141,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | service.port | int | `5678` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.automount | bool | `true` |  |
+| serviceAccount.automount | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -44,6 +44,10 @@ root filesystem as read-only with privilege escalation disabled. These settings
 are defined in `podSecurityContext` and `securityContext` in `values.yaml` and
 can be adjusted if needed.
 
+Automatic mounting of the ServiceAccount token is disabled via
+`serviceAccount.automount` to limit access to the Kubernetes API and reduce the
+attack surface.
+
 ## Updating n8n versions
 
 When a new n8n release is published, bump the `appVersion` field in

--- a/n8n/tests/serviceaccount_test.yaml
+++ b/n8n/tests/serviceaccount_test.yaml
@@ -1,0 +1,9 @@
+suite: serviceaccount
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: disables automount by default
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -24,7 +24,7 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Automatically mount a ServiceAccount's API credentials?
-  automount: true
+  automount: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
## Summary
- default ServiceAccount automount disabled in Helm values
- document why it's off by default
- test that ServiceAccount automount is false

## Testing
- `helm unittest n8n`
- `helm lint n8n`
- `helm lint --values n8n/values.yaml n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684d8d16c334832a92ee82f144a2bb21