### PR TITLE
Add seccomp profile to pod security context

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -125,6 +125,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | rbac.create | bool | `false` |  |
 | readinessProbe.httpGet.path | string | `"/"` |  |
 | readinessProbe.httpGet.port | string | `"http"` |  |

--- a/n8n/tests/securitycontext_test.yaml
+++ b/n8n/tests/securitycontext_test.yaml
@@ -11,6 +11,9 @@ tests:
           path: spec.template.spec.securityContext.fsGroup
           value: 1000
       - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
       - equal:

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -62,7 +62,14 @@
       "type": "object",
       "properties": {
         "runAsUser": { "type": "integer" },
-        "fsGroup": { "type": "integer" }
+        "fsGroup": { "type": "integer" },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     },

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -45,6 +45,8 @@ podLabels: {}
 podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   runAsNonRoot: true


### PR DESCRIPTION
## Summary
- default seccomp profile RuntimeDefault
- validate new field in values schema
- document new option in README
- test seccomp profile rendering

## Testing
- `helm unittest n8n`

------
https://chatgpt.com/codex/tasks/task_e_684d8e43b538832a9b35ea28d1768bc8