### PR TITLE
Add initContainers support

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -32,6 +32,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **extraEnv** – additional environment variables passed to the container.
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
+- **initContainers** – additional init containers executed before the main pod.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
 
@@ -107,6 +108,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| initContainers | list | `[]` |  |
 | livenessProbe.httpGet.path | string | `"/"` |  |
 | livenessProbe.httpGet.port | string | `"http"` |  |
 | nameOverride | string | `""` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -32,6 +32,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **extraEnv** – additional environment variables passed to the container.
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
+- **initContainers** – additional init containers executed before the main pod.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
 

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/n8n/tests/initcontainers_test.yaml
+++ b/n8n/tests/initcontainers_test.yaml
@@ -1,0 +1,21 @@
+suite: init containers
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: is not rendered when none are defined
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+  - it: renders provided init containers
+    set:
+      initContainers:
+        - name: init-db
+          image: busybox
+          command: ["sh", "-c", "echo hi"]
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-db
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -264,6 +264,7 @@
         "additionalProperties": false
       }
     },
+    "initContainers": { "type": "array", "items": { "type": "object" } },
     "nodeSelector": {
       "type": "object",
       "additionalProperties": { "type": "string" }

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -175,6 +175,12 @@ extraConfigMaps: []
 # - name: my-config
 #   mountPath: /etc/config
 
+# Define init containers executed before the main n8n container starts.
+initContainers: []
+# - name: init-db
+#   image: busybox
+#   command: ["sh", "-c", "echo initializing"]
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Summary
- add `initContainers` entry in values and schema
- render init containers in deployment
- document new option
- add helm unittest for `initContainers`

## Testing
- `helm lint n8n`
- `helm lint --values n8n/values.yaml n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684d9078d13c832abb464c594bdff48c