### PR TITLE
Add lifecycle hooks configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this Helm chart will be documented in this file.
 
+## [0.1.9] - 2025-06-14
+### Added
+- Lifecycle hooks configuration.
+
 ## [0.1.8] - 2025-06-14
 ### Added
 - Support for mounting an existing PersistentVolumeClaim.

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -33,6 +33,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **initContainers** – additional init containers executed before the main pod.
+- **lifecycle** – container lifecycle hooks such as preStop and postStart.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
 
@@ -109,6 +110,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
+| lifecycle | object | `{}` |  |
 | livenessProbe.httpGet.path | string | `"/"` |  |
 | livenessProbe.httpGet.port | string | `"http"` |  |
 | nameOverride | string | `""` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -33,6 +33,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **initContainers** – additional init containers executed before the main pod.
+- **lifecycle** – container lifecycle hooks such as preStop and postStart.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
 

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -94,6 +94,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/n8n/tests/lifecycle_test.yaml
+++ b/n8n/tests/lifecycle_test.yaml
@@ -1,0 +1,24 @@
+suite: lifecycle hooks
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: is not rendered when none are defined
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+  - it: renders provided lifecycle hooks
+    set:
+      lifecycle:
+        preStop:
+          exec:
+            command: ["sh", "-c", "sleep 5"]
+        postStart:
+          exec:
+            command: ["sh", "-c", "echo hi"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          value: "sleep 5"
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
+          value: "echo hi"

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -206,6 +206,7 @@
     "resources": { "type": "object" },
     "livenessProbe": { "type": "object" },
     "readinessProbe": { "type": "object" },
+    "lifecycle": { "type": "object" },
     "autoscaling": {
       "type": "object",
       "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -132,6 +132,14 @@ readinessProbe:
   httpGet:
     path: /
     port: http
+# Optional lifecycle hooks. See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+lifecycle: {}
+# postStart:
+#   exec:
+#     command: ["sh", "-c", "echo started"]
+# preStop:
+#   exec:
+#     command: ["sh", "-c", "echo stopping"]
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:


### PR DESCRIPTION
## Summary
- support container lifecycle hooks via new `lifecycle` values
- document lifecycle options
- update chart to version 0.1.9
- add lifecycle unit tests

## Testing
- `helm lint n8n`
- `helm lint --values n8n/values.yaml n8n`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684d92102560832a8638d996385031a7