### PR TITLE
Add cosign signing to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,25 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Run chart-releaser
+        id: cr
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: n8n
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign chart packages and upload signatures
+        if: steps.cr.outputs.changed_charts != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_EXPERIMENTAL: 'true'
+        run: |
+          for pkg in .cr-release-packages/*.tgz; do
+            cosign sign-blob --yes --output-signature "$pkg.sig" "$pkg"
+            tag=$(basename "$pkg" .tgz)
+            gh release upload "$tag" "$pkg.sig" --clobber
+          done
+


### PR DESCRIPTION
## Summary
- add cosign install step
- sign packaged charts and upload signatures after running chart-releaser

## Testing
- `helm lint n8n`
- `helm lint --values n8n/values.yaml n8n`
- `helm unittest n8n`
- `helm template n8n`


------
https://chatgpt.com/codex/tasks/task_e_684d9979efb8832abd9001440554dd06