### PR TITLE
Add logLevel option

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -29,6 +29,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
+- **logLevel** – set the verbosity of n8n logs.
 - **extraEnv** – additional environment variables passed to the container.
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
@@ -113,6 +114,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | lifecycle | object | `{}` |  |
 | livenessProbe.httpGet.path | string | `"/"` |  |
 | livenessProbe.httpGet.port | string | `"http"` |  |
+| logLevel | string | `"info"` |  |
 | nameOverride | string | `""` |  |
 | networkPolicy.egress | list | `[]` |  |
 | networkPolicy.enabled | bool | `false` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -29,6 +29,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
+- **logLevel** – set the verbosity of n8n logs.
 - **extraEnv** – additional environment variables passed to the container.
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -47,8 +47,10 @@ spec:
           {{- $db := .Values.database }}
           {{- $secret := $db.passwordSecret }}
           {{- $enc := .Values.encryptionKeySecret }}
-          {{- if or $db.host $db.port $db.user $db.password $secret.name $db.database $enc.name (gt (len .Values.extraEnv) 0) }}
+          {{- if or $db.host $db.port $db.user $db.password $secret.name $db.database $enc.name (gt (len .Values.extraEnv) 0) .Values.logLevel }}
           env:
+            - name: N8N_LOG_LEVEL
+              value: "{{ .Values.logLevel }}"
             {{- if $db.host }}
             - name: DB_POSTGRESDB_HOST
               value: "{{ $db.host }}"

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -104,6 +104,10 @@
         "additionalProperties": false
       }
     },
+    "logLevel": {
+      "type": "string",
+      "enum": ["error", "warn", "info", "debug", "silent"]
+    },
     "database": {
       "type": "object",
       "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -61,6 +61,10 @@ extraEnv: []
 # - name: N8N_BASIC_AUTH_ACTIVE
 #   value: "true"
 
+# Log level for n8n. See https://docs.n8n.io/reference/environment-variables/#n8n_log_level
+# for allowed values.
+logLevel: info
+
 # Connection details for an external PostgreSQL database. Leave values empty to
 # use the built-in SQLite storage.
 database:


### PR DESCRIPTION
## Summary
- expose `logLevel` in the chart values and schema
- inject `N8N_LOG_LEVEL` env var in the Deployment
- document `logLevel` in the chart README

## Testing
- `helm lint n8n`
- `helm lint --values n8n/values.yaml n8n`
- `helm unittest n8n`
- `helm template n8n`
- `helm-docs`


------
https://chatgpt.com/codex/tasks/task_e_684d9b749314832a9f7aa2d6ffc4a6b1