### PR TITLE
Fix trivy action tag

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Helm lint
         run: helm lint n8n
       - name: Helm lint with values
-        run: helm lint --values n8n/values.yaml
+        run: helm lint n8n --values n8n/values.yaml
       - name: Helm unit tests
         run: helm unittest n8n
       - name: Helm template

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Helm template
         run: helm template n8n
       - name: Scan for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.14.0
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           scan-type: fs
           scan-ref: n8n


### PR DESCRIPTION
## Summary
- correct the Trivy action tag in the lint workflow

## Testing
- `helm lint n8n` *(fails: `helm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d9c99df60832aabfe299e9d3b83f9