### PR TITLE
Support extra containers

### DIFF
--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -33,6 +33,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **initContainers** – additional init containers executed before the main pod.
+- **extraContainers** – additional containers running alongside the main pod.
 - **lifecycle** – container lifecycle hooks such as preStop and postStart.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
@@ -70,6 +71,17 @@ helm install my-n8n n8n/n8n \
   --set resources.limits.memory=1Gi
 ```
 
+## Extra containers example
+
+Additional sidecars can be defined via `extraContainers`:
+
+```yaml
+extraContainers:
+  - name: sidecar
+    image: busybox
+    command: ["sh", "-c", "echo sidecar"]
+```
+
 ## Publishing
 
 Chart packages are created automatically using [chart-releaser](https://github.com/helm/chart-releaser) when commits land on `main`.
@@ -95,6 +107,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | encryptionKeySecret.key | string | `"encryptionKey"` |  |
 | encryptionKeySecret.name | string | `""` |  |
 | extraConfigMaps | list | `[]` |  |
+| extraContainers | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraSecrets | list | `[]` |  |
 | fullnameOverride | string | `""` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -33,6 +33,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **initContainers** – additional init containers executed before the main pod.
+- **extraContainers** – additional containers running alongside the main pod.
 - **lifecycle** – container lifecycle hooks such as preStop and postStart.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
@@ -68,6 +69,17 @@ helm install my-n8n n8n/n8n \
   --set resources.requests.memory=512Mi \
   --set resources.limits.cpu=1 \
   --set resources.limits.memory=1Gi
+```
+
+## Extra containers example
+
+Additional sidecars can be defined via `extraContainers`:
+
+```yaml
+extraContainers:
+  - name: sidecar
+    image: busybox
+    command: ["sh", "-c", "echo sidecar"]
 ```
 
 ## Publishing

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -138,6 +138,9 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.persistence.enabled }}
       volumes:
         - name: data

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -266,6 +266,7 @@
       }
     },
     "initContainers": { "type": "array", "items": { "type": "object" } },
+    "extraContainers": { "type": "array", "items": { "type": "object" } },
     "nodeSelector": {
       "type": "object",
       "additionalProperties": { "type": "string" }

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -189,6 +189,12 @@ initContainers: []
 #   image: busybox
 #   command: ["sh", "-c", "echo initializing"]
 
+# Additional sidecar containers running alongside n8n.
+extraContainers: []
+# - name: sidecar
+#   image: busybox
+#   command: ["sh", "-c", "echo sidecar"]
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Summary
- allow specifying extra containers via `extraContainers`
- document with example in README
- render the containers in the Deployment
- bump chart version to 0.1.10

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`
- `helm template n8n`


------
https://chatgpt.com/codex/tasks/task_e_684db193b7c0832abbe9e9126080937f