### PR TITLE
Add rollout strategy support

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -162,6 +162,9 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | serviceAccount.automount | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| strategy.maxSurge | string | `"25%"` |  |
+| strategy.maxUnavailable | string | `"25%"` |  |
+| strategy.type | string | `"RollingUpdate"` |  |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -8,6 +8,15 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    type: {{ .type }}
+    {{- if eq .type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .maxSurge }}
+      maxUnavailable: {{ .maxUnavailable }}
+    {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "n8n.selectorLabels" . | nindent 6 }}

--- a/n8n/tests/strategy_test.yaml
+++ b/n8n/tests/strategy_test.yaml
@@ -1,0 +1,20 @@
+suite: strategy
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: sets custom rolling update values
+    set:
+      strategy:
+        type: RollingUpdate
+        maxSurge: 2
+        maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 2
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -272,7 +272,16 @@
       "additionalProperties": { "type": "string" }
     },
     "tolerations": { "type": "array", "items": { "type": "object" } },
-    "affinity": { "type": "object" }
+    "affinity": { "type": "object" },
+    "strategy": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string" },
+        "maxSurge": { "type": ["integer", "string"] },
+        "maxUnavailable": { "type": ["integer", "string"] }
+      },
+      "additionalProperties": false
+    }
   },
   "additionalProperties": false
 }

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -200,3 +200,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Deployment strategy configuration.
+strategy:
+  type: RollingUpdate
+  maxSurge: 25%
+  maxUnavailable: 25%


### PR DESCRIPTION
## Summary
- configure deployment strategy via `strategy` block in `values.yaml`
- validate strategy values in `values.schema.json`
- use strategy in deployment template
- document new values
- test rolling update configuration

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`


------
https://chatgpt.com/codex/tasks/task_e_684db30aa350832ab8400b6f5d5223e4