### PR TITLE
Add workflow to update n8n version

### DIFF
--- a/.github/workflows/check-n8n-version.yaml
+++ b/.github/workflows/check-n8n-version.yaml
@@ -1,0 +1,47 @@
+name: Check n8n Image Version
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest n8n version
+        id: latest
+        run: |
+          latest=$(curl -s "https://hub.docker.com/v2/repositories/n8nio/n8n/tags?page_size=50" \
+            | jq -r '.results[].name' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V \
+            | tail -n1)
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+      - name: Get chart version
+        id: current
+        run: |
+          current=$(grep '^appVersion:' n8n/Chart.yaml | awk '{print $2}' | tr -d '"')
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+      - name: Install helm-docs
+        if: steps.latest.outputs.latest != steps.current.outputs.current
+        run: |
+          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+            | tar -xz -C /usr/local/bin helm-docs
+      - name: Update files
+        if: steps.latest.outputs.latest != steps.current.outputs.current
+        run: |
+          sed -i -E "s/appVersion: \".*\"/appVersion: \"${{ steps.latest.outputs.latest }}\"/" n8n/Chart.yaml
+          sed -i -E "s/tag: \".*\"/tag: \"${{ steps.latest.outputs.latest }}\"/" n8n/values.yaml
+          helm-docs
+      - name: Create Pull Request
+        if: steps.latest.outputs.latest != steps.current.outputs.current
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: update n8n version to ${{ steps.latest.outputs.latest }}"
+          title: "chore: update n8n version to ${{ steps.latest.outputs.latest }}"
+          body: "Automated update of n8n image version to ${{ steps.latest.outputs.latest }}."
+          branch: "update-n8n-${{ steps.latest.outputs.latest }}"
+          delete-branch: true
+          labels: automated


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to check new n8n Docker image tags and open a pull request with version updates

## Testing
- `helm lint n8n` *(fails: `helm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684db46f456c832aba557282e0adc24c