### PR TITLE
Update docs for gh-pages setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,11 +418,12 @@ helm install my-n8n n8n/n8n \
 Chart releases are handled automatically by [chart-releaser](https://github.com/helm/chart-releaser).
 To publish a new version:
 
-1. Update the `version` (and optionally `appVersion`) fields in `n8n/Chart.yaml`.
-2. Record the changes in `CHANGELOG.md`.
-3. Commit the change to the `main` branch.
-4. Push the commit to GitHub. The [`release.yaml`](.github/workflows/release.yaml) workflow packages the chart from the `n8n` directory and uploads it to a GitHub release.
-5. Once the workflow completes, the repository index on the `gh-pages` branch is updated at <https://anyfavors.github.io/n8n-helm>.
+1. Ensure a branch named `gh-pages` exists in the repository and configure GitHub Pages to use it. The branch can start with an empty `index.yaml` file.
+2. Update the `version` (and optionally `appVersion`) fields in `n8n/Chart.yaml`.
+3. Record the changes in `CHANGELOG.md`.
+4. Commit the change to the `main` branch.
+5. Push the commit to GitHub. The [`release.yaml`](.github/workflows/release.yaml) workflow packages the chart from the `n8n` directory and uploads it to a GitHub release.
+6. Once the workflow completes, the repository index on the `gh-pages` branch is updated at <https://anyfavors.github.io/n8n-helm>.
 
 ## License
 

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -94,6 +94,7 @@ extraContainers:
 ## Publishing
 
 Chart packages are created automatically using [chart-releaser](https://github.com/helm/chart-releaser) when commits land on `main`.
+Before the first release, create a `gh-pages` branch in the repository and configure GitHub Pages to serve from it (the branch can start with an empty `index.yaml`).
 To cut a release, bump the version in `Chart.yaml` and push the change. The [`release.yaml`](../.github/workflows/release.yaml) workflow will upload the packaged chart to GitHub and update the index on `gh-pages`.
 Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository to install published versions.
 

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -94,6 +94,7 @@ extraContainers:
 ## Publishing
 
 Chart packages are created automatically using [chart-releaser](https://github.com/helm/chart-releaser) when commits land on `main`.
+Before the first release, create a `gh-pages` branch in the repository and configure GitHub Pages to serve from it (the branch can start with an empty `index.yaml`).
 To cut a release, bump the version in `Chart.yaml` and push the change. The [`release.yaml`](../.github/workflows/release.yaml) workflow will upload the packaged chart to GitHub and update the index on `gh-pages`.
 Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository to install published versions.
 


### PR DESCRIPTION
## Summary
- mention the need to create a `gh-pages` branch before running the release workflow
- regenerate chart README

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684db7ca027c832a9c0e81b4e89f7ada