### PR TITLE
Support StatefulSet when persistence enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ echo http://$NODE_IP:$NODE_PORT
 
 ## Persistence
 
-Set `persistence.enabled` to `true` to store workflows and other n8n data on a persistent volume. The claim size and storage class can be adjusted with the `size` and `storageClass` values, or supply `existingClaim` to mount a pre-created PersistentVolumeClaim. Data is mounted at `/home/node/.n8n` inside the pod.
+Set `persistence.enabled` to `true` to deploy a StatefulSet that stores workflows and other n8n data on a persistent volume. The claim size and storage class can be adjusted with the `size` and `storageClass` values, or supply `existingClaim` to mount a pre-created PersistentVolumeClaim. Data is mounted at `/home/node/.n8n` inside the pod.
 
 ```yaml
 persistence:

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -22,7 +22,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **replicaCount** – number of pods to run.
 - **image.tag** – n8n container image tag to deploy.
 - **ingress.enabled** – expose the service using an ingress resource.
-- **persistence.enabled** – store workflows on a persistent volume.
+- **persistence.enabled** – store workflows on a persistent volume using a StatefulSet.
 - **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic.
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -22,7 +22,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **replicaCount** – number of pods to run.
 - **image.tag** – n8n container image tag to deploy.
 - **ingress.enabled** – expose the service using an ingress resource.
-- **persistence.enabled** – store workflows on a persistent volume.
+- **persistence.enabled** – store workflows on a persistent volume using a StatefulSet.
 - **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic.
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.

--- a/n8n/templates/statefulset.yaml
+++ b/n8n/templates/statefulset.yaml
@@ -1,22 +1,14 @@
-{{- if not .Values.persistence.enabled }}
+{{- if .Values.persistence.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "n8n.fullname" . }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
-  {{- with .Values.strategy }}
-  strategy:
-    type: {{ .type }}
-    {{- if eq .type "RollingUpdate" }}
-    rollingUpdate:
-      maxSurge: {{ .maxSurge }}
-      maxUnavailable: {{ .maxUnavailable }}
-    {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/n8n/tests/deployment_test.yaml
+++ b/n8n/tests/deployment_test.yaml
@@ -11,8 +11,6 @@ tests:
     set:
       persistence:
         enabled: true
-        existingClaim: my-data
     asserts:
-      - equal:
-          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
-          value: my-data
+      - hasDocuments:
+          count: 0

--- a/n8n/tests/statefulset_test.yaml
+++ b/n8n/tests/statefulset_test.yaml
@@ -1,0 +1,17 @@
+suite: statefulset
+templates:
+  - templates/statefulset.yaml
+tests:
+  - it: is not rendered when persistence disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: mounts existing pvc when configured
+    set:
+      persistence:
+        enabled: true
+        existingClaim: my-data
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: my-data

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -231,7 +231,7 @@
     "persistence": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean", "description": "Deploy a StatefulSet with persistent storage" },
         "size": { "type": "string" },
         "storageClass": { "type": "string" },
         "existingClaim": { "type": "string" }


### PR DESCRIPTION
## Summary
- use a StatefulSet when persistence.enabled is true
- describe the new behavior in docs
- document persistent StatefulSet in values schema
- adjust deployment template logic
- add tests for the StatefulSet

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684dc2115864832a9b77bd984a892dbb