### PR TITLE
Add command/args customization

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -35,6 +35,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **initContainers** – additional init containers executed before the main pod.
 - **extraContainers** – additional containers running alongside the main pod.
+- **command** – override the container entrypoint.
+- **args** – container arguments passed to the command.
 - **lifecycle** – container lifecycle hooks such as preStop and postStart.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
@@ -103,10 +105,12 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| args | list | `[]` |  |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| command | list | `[]` |  |
 | database.database | string | `""` |  |
 | database.host | string | `""` |  |
 | database.password | string | `""` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -35,6 +35,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **initContainers** – additional init containers executed before the main pod.
 - **extraContainers** – additional containers running alongside the main pod.
+- **command** – override the container entrypoint.
+- **args** – container arguments passed to the command.
 - **lifecycle** – container lifecycle hooks such as preStop and postStart.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -54,6 +54,14 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- $db := .Values.database }}
           {{- $secret := $db.passwordSecret }}
           {{- $enc := .Values.encryptionKeySecret }}

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -207,6 +207,8 @@
     "resources": { "type": "object" },
     "livenessProbe": { "type": "object" },
     "readinessProbe": { "type": "object" },
+    "command": { "type": "array", "items": { "type": "string" } },
+    "args": { "type": "array", "items": { "type": "string" } },
     "lifecycle": { "type": "object" },
     "autoscaling": {
       "type": "object",

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -136,6 +136,13 @@ readinessProbe:
   httpGet:
     path: /
     port: http
+# Override the container entrypoint
+command: []
+# - n8n
+
+# Arguments to pass to the container entrypoint
+args: []
+# - start
 # Optional lifecycle hooks. See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 lifecycle: {}
 # postStart:


### PR DESCRIPTION
## Summary
- allow customizing container command and args
- update Helm chart schema
- document new options

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684dc47f0bd8832a8e80fea3f9e48d77