### PR TITLE
Add podAntiAffinity support

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -153,6 +153,8 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | persistence.size | string | `"8Gi"` |  |
 | persistence.storageClass | string | `""` |  |
 | podAnnotations | object | `{}` |  |
+| podAntiAffinity.hard | list | `[]` |  |
+| podAntiAffinity.soft | list | `[]` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -205,9 +205,24 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- $anti := .Values.podAntiAffinity }}
+      {{- $affinity := .Values.affinity }}
+      {{- if or $affinity (or (gt (len $anti.hard) 0) (gt (len $anti.soft) 0)) }}
       affinity:
+        {{- with $affinity }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if or (gt (len $anti.hard) 0) (gt (len $anti.soft) 0) }}
+        podAntiAffinity:
+          {{- with $anti.hard }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $anti.soft }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -275,6 +275,14 @@
       "additionalProperties": { "type": "string" }
     },
     "tolerations": { "type": "array", "items": { "type": "object" } },
+    "podAntiAffinity": {
+      "type": "object",
+      "properties": {
+        "hard": { "type": "array", "items": { "type": "object" } },
+        "soft": { "type": "array", "items": { "type": "object" } }
+      },
+      "additionalProperties": false
+    },
     "affinity": { "type": "object" },
     "strategy": {
       "type": "object",

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -210,6 +210,29 @@ nodeSelector: {}
 
 tolerations: []
 
+# Pod anti-affinity rules. Soft rules are expressed as
+# preferredDuringSchedulingIgnoredDuringExecution and hard rules as
+# requiredDuringSchedulingIgnoredDuringExecution.
+podAntiAffinity:
+  hard: []
+  # - labelSelector:
+  #     matchExpressions:
+  #       - key: app.kubernetes.io/name
+  #         operator: In
+  #         values:
+  #           - n8n
+  #   topologyKey: kubernetes.io/hostname
+  soft: []
+  # - weight: 100
+  #   podAffinityTerm:
+  #     labelSelector:
+  #       matchExpressions:
+  #         - key: app.kubernetes.io/name
+  #           operator: In
+  #           values:
+  #             - n8n
+  #     topologyKey: kubernetes.io/hostname
+
 affinity: {}
 
 # Deployment strategy configuration.


### PR DESCRIPTION
## Summary
- document podAntiAffinity examples in `values.yaml`
- describe podAntiAffinity options in the values schema
- include podAntiAffinity rules in the Deployment template when specified
- regenerate chart docs

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684dc93f66e8832a8e2678058063f933