### PR TITLE
Add security context options

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -50,6 +50,14 @@ root filesystem as read-only with privilege escalation disabled. These settings
 are defined in `podSecurityContext` and `securityContext` in `values.yaml` and
 can be adjusted if needed.
 
+Recommended security values:
+
+- `podSecurityContext.runAsUser`: `1000`
+- `podSecurityContext.runAsGroup`: `1000`
+- `podSecurityContext.fsGroup`: `1000`
+- `podSecurityContext.fsGroupChangePolicy`: `OnRootMismatch`
+- `podSecurityContext.seccompProfile.type`: `RuntimeDefault`
+
 Automatic mounting of the ServiceAccount token is disabled via
 `serviceAccount.automount` to limit access to the Kubernetes API and reduce the
 attack surface.
@@ -157,6 +165,8 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | podAntiAffinity.soft | list | `[]` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
+| podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
+| podSecurityContext.runAsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
 | podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | rbac.create | bool | `false` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -50,6 +50,14 @@ root filesystem as read-only with privilege escalation disabled. These settings
 are defined in `podSecurityContext` and `securityContext` in `values.yaml` and
 can be adjusted if needed.
 
+Recommended security values:
+
+- `podSecurityContext.runAsUser`: `1000`
+- `podSecurityContext.runAsGroup`: `1000`
+- `podSecurityContext.fsGroup`: `1000`
+- `podSecurityContext.fsGroupChangePolicy`: `OnRootMismatch`
+- `podSecurityContext.seccompProfile.type`: `RuntimeDefault`
+
 Automatic mounting of the ServiceAccount token is disabled via
 `serviceAccount.automount` to limit access to the Kubernetes API and reduce the
 attack surface.

--- a/n8n/tests/securitycontext_test.yaml
+++ b/n8n/tests/securitycontext_test.yaml
@@ -8,8 +8,14 @@ tests:
           path: spec.template.spec.securityContext.runAsUser
           value: 1000
       - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 1000
+      - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroupChangePolicy
+          value: OnRootMismatch
       - equal:
           path: spec.template.spec.securityContext.seccompProfile.type
           value: RuntimeDefault

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -62,7 +62,9 @@
       "type": "object",
       "properties": {
         "runAsUser": { "type": "integer" },
+        "runAsGroup": { "type": "integer" },
         "fsGroup": { "type": "integer" },
+        "fsGroupChangePolicy": { "type": "string" },
         "seccompProfile": {
           "type": "object",
           "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -44,7 +44,9 @@ podLabels: {}
 
 podSecurityContext:
   runAsUser: 1000
+  runAsGroup: 1000
   fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
   seccompProfile:
     type: RuntimeDefault
 


### PR DESCRIPTION
## Summary
- add runAsGroup, seccompProfile and fsGroupChangePolicy defaults
- document recommended security context settings
- update tests for new security fields

## Testing
- `helm lint .`
- `helm lint . --values values.yaml`
- `helm unittest .`


------
https://chatgpt.com/codex/tasks/task_e_684dcbb9c150832ab5b2342303290c41