### PR TITLE
Enable network policies by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,14 +207,10 @@ The chart also includes a `values.schema.json` file that defines the allowed str
 
 ## Network policies
 
-Set `networkPolicy.enabled` to `true` to create a `NetworkPolicy` resource that denies all traffic by default. Custom ingress and egress rules can be added under `networkPolicy.ingress` and `networkPolicy.egress`.
-
-Example enabling the policy from the command line:
-
-```bash
-helm install my-n8n n8n/n8n \
-  --set networkPolicy.enabled=true
-```
+`networkPolicy.enabled` defaults to `true`, creating a `NetworkPolicy` that
+denies all ingress and egress traffic. Extend the policy under
+`networkPolicy.ingress` and `networkPolicy.egress` to permit connections.
+Disable the policy entirely by setting `networkPolicy.enabled=false`.
 
 To allow specific traffic, extend the policy in your values file:
 

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -24,7 +24,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume using a StatefulSet.
 - **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
-- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic.
+- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (enabled by default).
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
@@ -150,7 +150,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | livenessProbe.httpGet.port | string | `"http"` |  |
 | nameOverride | string | `""` |  |
 | networkPolicy.egress | list | `[]` |  |
-| networkPolicy.enabled | bool | `false` |  |
+| networkPolicy.enabled | bool | `true` |  |
 | networkPolicy.ingress | list | `[]` |  |
 | networkPolicy.policyTypes[0] | string | `"Ingress"` |  |
 | networkPolicy.policyTypes[1] | string | `"Egress"` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -24,7 +24,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume using a StatefulSet.
 - **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
-- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic.
+- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (enabled by default).
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.

--- a/n8n/templates/networkpolicy.yaml
+++ b/n8n/templates/networkpolicy.yaml
@@ -13,16 +13,38 @@ spec:
 {{- range .Values.networkPolicy.policyTypes }}
     - {{ . }}
 {{- end }}
+  # Deny all incoming traffic by default. Add entries under
+  # `networkPolicy.ingress` in your values file to allow specific sources.
   {{- if .Values.networkPolicy.ingress }}
   ingress:
     {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
   {{- else }}
   ingress: []
+  # Example to allow traffic from a namespace:
+  # ingress:
+  #   - from:
+  #       - namespaceSelector:
+  #           matchLabels:
+  #             name: my-namespace
+  #     ports:
+  #       - protocol: TCP
+  #         port: 5678
   {{- end }}
+
+  # Deny all outgoing traffic by default. Add entries under
+  # `networkPolicy.egress` to permit destinations such as databases or APIs.
   {{- if .Values.networkPolicy.egress }}
   egress:
     {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
   {{- else }}
   egress: []
+  # Example to allow egress to a CIDR block:
+  # egress:
+  #   - to:
+  #       - ipBlock:
+  #           cidr: 10.0.0.0/24
+  #     ports:
+  #       - protocol: TCP
+  #         port: 5432
   {{- end }}
 {{- end }}

--- a/n8n/tests/networkpolicy_test.yaml
+++ b/n8n/tests/networkpolicy_test.yaml
@@ -3,6 +3,9 @@ templates:
   - templates/networkpolicy.yaml
 tests:
   - it: is not rendered when disabled
+    set:
+      networkPolicy:
+        enabled: false
     asserts:
       - hasDocuments:
           count: 0

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -112,7 +112,7 @@ ingress:
   #      - chart-example.local
 
 networkPolicy:
-  enabled: false
+  enabled: true
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
## Summary
- make `networkPolicy.enabled` default to true
- document how to allow ingress/egress traffic
- explain that network policies are enabled by default
- provide deny-all rules with comments on how to extend them

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`
- `helm template n8n`


------
https://chatgpt.com/codex/tasks/task_e_684dcd9a79c0832a8a2c39886c44dc50