### PR TITLE
Add pod security labels support

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,16 @@ metadata:
     pod-security.kubernetes.io/warn: restricted
 ```
 
+You can also have the chart manage these labels automatically by setting the
+`podSecurity` values at install time:
+
+```bash
+helm install my-n8n n8n/n8n \
+  --set podSecurity.enforce=restricted \
+  --set podSecurity.audit=restricted \
+  --set podSecurity.warn=restricted
+```
+
 ## Pod disruption budgets
 
 Create a PodDisruptionBudget to control the number of pods that may be

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -62,6 +62,16 @@ Automatic mounting of the ServiceAccount token is disabled via
 `serviceAccount.automount` to limit access to the Kubernetes API and reduce the
 attack surface.
 
+The chart can also manage Pod Security Admission labels on the release
+namespace. Specify the desired levels under the `podSecurity` block:
+
+```yaml
+podSecurity:
+  enforce: restricted
+  audit: restricted
+  warn: restricted
+```
+
 ## Updating n8n versions
 
 When a new n8n release is published, bump the `appVersion` field in
@@ -164,6 +174,9 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | podAntiAffinity.hard | list | `[]` |  |
 | podAntiAffinity.soft | list | `[]` |  |
 | podLabels | object | `{}` |  |
+| podSecurity.audit | string | `""` |  |
+| podSecurity.enforce | string | `""` |  |
+| podSecurity.warn | string | `""` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.fsGroupChangePolicy | string | `"OnRootMismatch"` |  |
 | podSecurityContext.runAsGroup | int | `1000` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -62,6 +62,17 @@ Automatic mounting of the ServiceAccount token is disabled via
 `serviceAccount.automount` to limit access to the Kubernetes API and reduce the
 attack surface.
 
+The chart can also manage Pod Security Admission labels on the release
+namespace. Specify the desired levels under the `podSecurity` block:
+
+```yaml
+podSecurity:
+  enforce: restricted
+  audit: restricted
+  warn: restricted
+```
+
+
 ## Updating n8n versions
 
 When a new n8n release is published, bump the `appVersion` field in

--- a/n8n/templates/podsecurity.yaml
+++ b/n8n/templates/podsecurity.yaml
@@ -1,0 +1,17 @@
+{{- if or .Values.podSecurity.enforce .Values.podSecurity.audit .Values.podSecurity.warn }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- if .Values.podSecurity.enforce }}
+    pod-security.kubernetes.io/enforce: {{ .Values.podSecurity.enforce | quote }}
+    {{- end }}
+    {{- if .Values.podSecurity.audit }}
+    pod-security.kubernetes.io/audit: {{ .Values.podSecurity.audit | quote }}
+    {{- end }}
+    {{- if .Values.podSecurity.warn }}
+    pod-security.kubernetes.io/warn: {{ .Values.podSecurity.warn | quote }}
+    {{- end }}
+{{- end }}
+

--- a/n8n/tests/podsecurity_test.yaml
+++ b/n8n/tests/podsecurity_test.yaml
@@ -1,0 +1,27 @@
+suite: podsecurity
+templates:
+  - templates/podsecurity.yaml
+tests:
+  - it: is not rendered when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: sets namespace labels
+    set:
+      podSecurity:
+        enforce: restricted
+        audit: restricted
+        warn: restricted
+    asserts:
+      - equal:
+          path: kind
+          value: Namespace
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/enforce"]
+          value: restricted
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/audit"]
+          value: restricted
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/warn"]
+          value: restricted

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -58,6 +58,15 @@
       "type": "object",
       "additionalProperties": { "type": "string" }
     },
+    "podSecurity": {
+      "type": "object",
+      "properties": {
+        "enforce": { "type": "string" },
+        "audit": { "type": "string" },
+        "warn": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
     "podSecurityContext": {
       "type": "object",
       "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -42,6 +42,13 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
+# Pod Security Admission labels to apply to the namespace.
+# See https://kubernetes.io/docs/concepts/security/pod-security-admission/
+podSecurity:
+  enforce: ""
+  audit: ""
+  warn: ""
+
 podSecurityContext:
   runAsUser: 1000
   runAsGroup: 1000


### PR DESCRIPTION
## Summary
- add `podSecurity` options to values
- generate namespace labels when pod security settings are given
- document pod security options in README
- bump chart version
- add unit tests

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`
- `helm template n8n`


------
https://chatgpt.com/codex/tasks/task_e_684dcf4ff638832a99235326e78dae25