### PR TITLE
Add metrics service and ServiceMonitor support

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -158,6 +158,9 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | lifecycle | object | `{}` |  |
 | livenessProbe.httpGet.path | string | `"/"` |  |
 | livenessProbe.httpGet.port | string | `"http"` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.port | int | `5678` |  |
+| metrics.serviceMonitor.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | networkPolicy.egress | list | `[]` |  |
 | networkPolicy.enabled | bool | `true` |  |

--- a/n8n/templates/service-metrics.yaml
+++ b/n8n/templates/service-metrics.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "n8n.fullname" . }}-metrics
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.metrics.port }}
+      targetPort: http
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "n8n.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/n8n/templates/servicemonitor.yaml
+++ b/n8n/templates/servicemonitor.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "n8n.fullname" . }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "n8n.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+{{- end }}

--- a/n8n/tests/service_metrics_test.yaml
+++ b/n8n/tests/service_metrics_test.yaml
@@ -1,0 +1,19 @@
+suite: metrics service
+templates:
+  - templates/service-metrics.yaml
+tests:
+  - it: is not rendered by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders service when enabled
+    set:
+      metrics:
+        enabled: true
+    asserts:
+      - equal:
+          path: kind
+          value: Service
+      - equal:
+          path: spec.ports[0].port
+          value: 5678

--- a/n8n/tests/servicemonitor_test.yaml
+++ b/n8n/tests/servicemonitor_test.yaml
@@ -1,0 +1,21 @@
+suite: service monitor
+templates:
+  - templates/servicemonitor.yaml
+tests:
+  - it: not rendered by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders ServiceMonitor when enabled
+    set:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - equal:
+          path: kind
+          value: ServiceMonitor
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -155,6 +155,21 @@
       },
       "additionalProperties": false
     },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "port": { "type": "integer" },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "ingress": {
       "type": "object",
       "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -101,6 +101,14 @@ service:
   # Annotations to add to the service
   annotations: {}
 
+# Expose Prometheus metrics on a dedicated service
+metrics:
+  enabled: false
+  # Port for the metrics service
+  port: 5678
+  serviceMonitor:
+    enabled: false
+
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary
- expose metrics on a dedicated service
- add optional ServiceMonitor for Prometheus Operator
- document new metrics settings
- cover metrics resources with unit tests

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`
- `helm template n8n`


------
https://chatgpt.com/codex/tasks/task_e_684dd4e04d74832a9fc44b1a1a3544be