### PR TITLE
Add secret generation options

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -29,6 +29,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
+- **generateEncryptionKey** – automatically create a secret with a random encryption key.
+- **generateDatabasePassword** – automatically create a secret with a random database password.
 - **webhookUrl** – external URL for webhook callbacks.
 - **extraEnv** – additional environment variables passed to the container.
 - **extraSecrets** – mount additional Secrets inside the pod.
@@ -149,6 +151,8 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | extraEnv | list | `[]` |  |
 | extraSecrets | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
+| generateDatabasePassword | bool | `false` |  |
+| generateEncryptionKey | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"n8nio/n8n"` |  |
 | image.tag | string | `""` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -29,6 +29,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
+- **generateEncryptionKey** – automatically create a secret with a random encryption key.
+- **generateDatabasePassword** – automatically create a secret with a random database password.
 - **webhookUrl** – external URL for webhook callbacks.
 - **extraEnv** – additional environment variables passed to the container.
 - **extraSecrets** – mount additional Secrets inside the pod.

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -63,8 +63,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- $db := .Values.database }}
-          {{- $secret := $db.passwordSecret }}
-          {{- $enc := .Values.encryptionKeySecret }}
+          {{- $secret := ternary (dict "name" (printf "%s-db-password" (include "n8n.fullname" .)) "key" "password") $db.passwordSecret .Values.generateDatabasePassword }}
+          {{- $enc := ternary (dict "name" (printf "%s-encryption-key" (include "n8n.fullname" .)) "key" "encryptionKey") .Values.encryptionKeySecret .Values.generateEncryptionKey }}
           {{- $webhook := .Values.webhookUrl }}
           {{- if or $db.host $db.port $db.user $db.password $secret.name $db.database $enc.name $webhook (gt (len .Values.extraEnv) 0) }}
           env:

--- a/n8n/templates/secret.yaml
+++ b/n8n/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.generateDatabasePassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "n8n.fullname" . }}-db-password
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}
+{{- if .Values.generateEncryptionKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "n8n.fullname" . }}-encryption-key
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+type: Opaque
+data:
+  encryptionKey: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}

--- a/n8n/templates/statefulset.yaml
+++ b/n8n/templates/statefulset.yaml
@@ -47,8 +47,8 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           {{- $db := .Values.database }}
-          {{- $secret := $db.passwordSecret }}
-          {{- $enc := .Values.encryptionKeySecret }}
+          {{- $secret := ternary (dict "name" (printf "%s-db-password" (include "n8n.fullname" .)) "key" "password") $db.passwordSecret .Values.generateDatabasePassword }}
+          {{- $enc := ternary (dict "name" (printf "%s-encryption-key" (include "n8n.fullname" .)) "key" "encryptionKey") .Values.encryptionKeySecret .Values.generateEncryptionKey }}
           {{- $webhook := .Values.webhookUrl }}
           {{- if or $db.host $db.port $db.user $db.password $secret.name $db.database $enc.name $webhook (gt (len .Values.extraEnv) 0) }}
           env:

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -142,6 +142,8 @@
       },
       "additionalProperties": false
     },
+    "generateEncryptionKey": { "type": "boolean" },
+    "generateDatabasePassword": { "type": "boolean" },
     "webhookUrl": { "type": "string" },
     "service": {
       "type": "object",

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -88,6 +88,12 @@ encryptionKeySecret:
   name: ""
   key: encryptionKey
 
+# Generate a secret containing a random N8N_ENCRYPTION_KEY
+generateEncryptionKey: false
+
+# Generate a secret containing a random database password
+generateDatabasePassword: false
+
 # Base URL used for external webhook callbacks
 webhookUrl: ""
 # webhookUrl: https://my-n8n.example.com/


### PR DESCRIPTION
## Summary
- add generateEncryptionKey and generateDatabasePassword settings
- document new booleans
- generate secrets when flags are enabled
- reference generated secrets in deployments

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`


------
https://chatgpt.com/codex/tasks/task_e_684dda1c9044832a85af0815e5b548d8