### PR TITLE
Add helper macros for extra volumes

### DIFF
--- a/n8n/templates/_helpers.tpl
+++ b/n8n/templates/_helpers.tpl
@@ -60,3 +60,34 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+{{/*
+Extra volume mounts for secret and configmap additions.
+*/}}
+{{- define "n8n.extraVolumeMounts" -}}
+{{- range .Values.extraSecrets }}
+- name: secret-{{ .name }}
+  mountPath: {{ .mountPath }}
+  readOnly: {{ .readOnly | default true }}
+{{- end }}
+{{- range .Values.extraConfigMaps }}
+- name: config-{{ .name }}
+  mountPath: {{ .mountPath }}
+  readOnly: {{ .readOnly | default true }}
+{{- end }}
+{{- end }}
+
+{{/*
+Extra volumes for secret and configmap additions.
+*/}}
+{{- define "n8n.extraVolumes" -}}
+{{- range .Values.extraSecrets }}
+- name: secret-{{ .name }}
+  secret:
+    secretName: {{ .name }}
+{{- end }}
+{{- range .Values.extraConfigMaps }}
+- name: config-{{ .name }}
+  configMap:
+    name: {{ .name }}
+{{- end }}
+{{- end }}

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -132,16 +132,7 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- range .Values.extraSecrets }}
-            - name: secret-{{ .name }}
-              mountPath: {{ .mountPath }}
-              readOnly: {{ .readOnly | default true }}
-            {{- end }}
-            {{- range .Values.extraConfigMaps }}
-            - name: config-{{ .name }}
-              mountPath: {{ .mountPath }}
-              readOnly: {{ .readOnly | default true }}
-            {{- end }}
+            {{- include "n8n.extraVolumeMounts" . | nindent 12 }}
           {{- else }}
           {{- $vm := .Values.volumeMounts }}
           {{- if or (gt (len $vm) 0) (gt (len .Values.extraSecrets) 0) (gt (len .Values.extraConfigMaps) 0) }}
@@ -149,16 +140,7 @@ spec:
             {{- with $vm }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- range .Values.extraSecrets }}
-            - name: secret-{{ .name }}
-              mountPath: {{ .mountPath }}
-              readOnly: {{ .readOnly | default true }}
-            {{- end }}
-            {{- range .Values.extraConfigMaps }}
-            - name: config-{{ .name }}
-              mountPath: {{ .mountPath }}
-              readOnly: {{ .readOnly | default true }}
-            {{- end }}
+            {{- include "n8n.extraVolumeMounts" . | nindent 12 }}
           {{- end }}
           {{- end }}
         {{- with .Values.extraContainers }}
@@ -172,16 +154,7 @@ spec:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- range .Values.extraSecrets }}
-        - name: secret-{{ .name }}
-          secret:
-            secretName: {{ .name }}
-        {{- end }}
-        {{- range .Values.extraConfigMaps }}
-        - name: config-{{ .name }}
-          configMap:
-            name: {{ .name }}
-        {{- end }}
+        {{- include "n8n.extraVolumes" . | nindent 8 }}
       {{- else }}
       {{- $vol := .Values.volumes }}
       {{- if or (gt (len $vol) 0) (gt (len .Values.extraSecrets) 0) (gt (len .Values.extraConfigMaps) 0) }}
@@ -189,16 +162,7 @@ spec:
         {{- with $vol }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- range .Values.extraSecrets }}
-        - name: secret-{{ .name }}
-          secret:
-            secretName: {{ .name }}
-        {{- end }}
-        {{- range .Values.extraConfigMaps }}
-        - name: config-{{ .name }}
-          configMap:
-            name: {{ .name }}
-        {{- end }}
+        {{- include "n8n.extraVolumes" . | nindent 8 }}
       {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
## Summary
- define `n8n.extraVolumeMounts` and `n8n.extraVolumes` macros
- reuse these helpers in the Deployment template

## Testing
- `helm lint n8n`
- `helm unittest n8n`


------
https://chatgpt.com/codex/tasks/task_e_684ddf0fd550832a806d6feac6759117