### PR TITLE
Add tests for TLS, SA override, and PVC handling

### DIFF
--- a/n8n/tests/ingress_test.yaml
+++ b/n8n/tests/ingress_test.yaml
@@ -25,3 +25,23 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].pathType
           value: Prefix
+  - it: renders tls configuration
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: tls.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - secretName: n8n-tls
+            hosts:
+              - tls.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: n8n-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: tls.example.com

--- a/n8n/tests/persistence_test.yaml
+++ b/n8n/tests/persistence_test.yaml
@@ -27,3 +27,12 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: ignores storageClass when existing claim used
+    set:
+      persistence:
+        enabled: true
+        storageClass: fast
+        existingClaim: my-data
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/n8n/tests/serviceaccount_test.yaml
+++ b/n8n/tests/serviceaccount_test.yaml
@@ -7,3 +7,14 @@ tests:
       - equal:
           path: automountServiceAccountToken
           value: false
+  - it: overrides name when rbac disabled
+    set:
+      rbac:
+        create: false
+      serviceAccount:
+        create: true
+        name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa


### PR DESCRIPTION
## Summary
- test ingress with TLS
- test overriding service account name when RBAC disabled
- test persistence logic with storage class and existing claim

## Testing
- `helm unittest n8n`

------
https://chatgpt.com/codex/tasks/task_e_684ddf1140c8832aa272757555acc2eb