### PR TITLE
Enhance release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,3 +49,17 @@ jobs:
             gh release upload "$tag" "$pkg.sig" --clobber
           done
 
+      - name: Verify signatures
+        if: steps.cr.outputs.changed_charts != ''
+        run: |
+          for pkg in .cr-release-packages/*.tgz; do
+            cosign verify-blob --key cosign.pub --signature "$pkg.sig" "$pkg"
+          done
+
+      - name: Upload chart packages
+        if: steps.cr.outputs.changed_charts != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: chart-packages
+          path: .cr-release-packages/*.tgz
+

--- a/README.md
+++ b/README.md
@@ -438,6 +438,16 @@ To publish a new version:
 5. Push the commit to GitHub. The [`release.yaml`](.github/workflows/release.yaml) workflow packages the chart from the `n8n` directory and uploads it to a GitHub release.
 6. Once the workflow completes, the repository index on the `gh-pages` branch is updated at <https://anyfavors.github.io/n8n-helm>.
 
+## Verifying chart signatures
+
+Chart packages are signed using [cosign](https://docs.sigstore.dev/cosign/overview/). The corresponding `cosign.pub` public key is attached to each GitHub release.
+
+Download `cosign.pub` from the release assets and verify a package with:
+
+```bash
+cosign verify-blob --key cosign.pub --signature n8n-<version>.tgz.sig n8n-<version>.tgz
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- sign packages and verify them with cosign
- upload chart archives as workflow artifacts
- document how to verify packages using the public key

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`

------
https://chatgpt.com/codex/tasks/task_e_684ddf131c4c832a8f74671778a202b6