### PR TITLE
Configure Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "helm-docs/releases/download/v(?<currentValue>[0-9.]+)/helm-docs_[0-9.]+_Linux_x86_64.tar.gz"
+      ],
+      "depNameTemplate": "norwoodj/helm-docs",
+      "datasourceTemplate": "github-releases",
+      "replaceString": "helm-docs/releases/download/v{{{newValue}}}/helm-docs_{{{newValue}}}_Linux_x86_64.tar.gz"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -438,6 +438,15 @@ To publish a new version:
 5. Push the commit to GitHub. The [`release.yaml`](.github/workflows/release.yaml) workflow packages the chart from the `n8n` directory and uploads it to a GitHub release.
 6. Once the workflow completes, the repository index on the `gh-pages` branch is updated at <https://anyfavors.github.io/n8n-helm>.
 
+## Maintenance
+
+Automated dependency updates are handled by [Renovate](https://github.com/renovatebot/renovate).
+The configuration in [.github/renovate.json](.github/renovate.json) monitors the
+GitHub Actions used in this repository and the Helm tooling versions referenced
+in the workflows. When a new version of the `helm-docs` plugin or a GitHub
+Action becomes available, Renovate opens a pull request with the update.
+Maintainers should review these PRs and merge them once the checks pass.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
## Summary
- move Renovate config under `.github/`
- add regex manager for helm-docs plugin
- document the automatic update process in the README

## Testing
- `helm lint n8n`
- `helm unittest n8n`

------
https://chatgpt.com/codex/tasks/task_e_684ddf1d8ff4832aad454ce6ff6dd520