### PR TITLE
Expose probe path settings

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -40,6 +40,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **command** – override the container entrypoint.
 - **args** – container arguments passed to the command.
 - **lifecycle** – container lifecycle hooks such as preStop and postStart.
+- **livenessProbe.httpGet.path** – path used for the container liveness probe.
+- **readinessProbe.httpGet.path** – path used for the container readiness probe.
 - **resources** – CPU and memory requests/limits. Defaults are conservative and
   should be tuned for production installations.
 

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -111,11 +111,21 @@ spec:
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
+            httpGet:
+              path: {{ .httpGet.path | quote }}
+              port: {{ .httpGet.port | quote }}
+            {{- with omit . "httpGet" }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
+            httpGet:
+              path: {{ .httpGet.path | quote }}
+              port: {{ .httpGet.port | quote }}
+            {{- with omit . "httpGet" }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.lifecycle }}
           lifecycle:

--- a/n8n/templates/statefulset.yaml
+++ b/n8n/templates/statefulset.yaml
@@ -95,11 +95,21 @@ spec:
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
+            httpGet:
+              path: {{ .httpGet.path | quote }}
+              port: {{ .httpGet.port | quote }}
+            {{- with omit . "httpGet" }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
+            httpGet:
+              path: {{ .httpGet.path | quote }}
+              port: {{ .httpGet.port | quote }}
+            {{- with omit . "httpGet" }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.lifecycle }}
           lifecycle:

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -233,8 +233,28 @@
       "additionalProperties": false
     },
     "resources": { "type": "object" },
-    "livenessProbe": { "type": "object" },
-    "readinessProbe": { "type": "object" },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" }
+          }
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" }
+          }
+        }
+      }
+    },
     "command": { "type": "array", "items": { "type": "string" } },
     "args": { "type": "array", "items": { "type": "string" } },
     "lifecycle": { "type": "object" },

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -160,10 +160,12 @@ resources:
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
+    # HTTP path used by the liveness probe
     path: /
     port: http
 readinessProbe:
   httpGet:
+    # HTTP path used by the readiness probe
     path: /
     port: http
 # Override the container entrypoint


### PR DESCRIPTION
## Summary
- allow changing liveness and readiness probe paths
- use configured path values in Deployment and StatefulSet templates
- describe livenessProbe.httpGet.path and readinessProbe.httpGet.path in docs

## Testing
- `helm lint .`
- `helm lint . --values values.yaml`
- `helm unittest .`
- `helm template .`

------
https://chatgpt.com/codex/tasks/task_e_684ddf270c20832a8be3bc883889c46b