### PR TITLE
Fix renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
       ],
       "depNameTemplate": "norwoodj/helm-docs",
       "datasourceTemplate": "github-releases",
-      "replaceString": "helm-docs/releases/download/v{{{newValue}}}/helm-docs_{{{newValue}}}_Linux_x86_64.tar.gz"
+      "autoReplaceStringTemplate": "helm-docs/releases/download/v{{{newValue}}}/helm-docs_{{{newValue}}}_Linux_x86_64.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- fix regex manager field for Renovate

## Testing
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm template n8n`
- `helm unittest n8n`
- `helm schema-gen n8n/values.yaml > generated-values.schema.json`


------
https://chatgpt.com/codex/tasks/task_e_684de45fdbe0832a8ecfccf909b7337e