### PR TITLE
Fix CI by building chart dependencies

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,8 @@ jobs:
         run: |
           helm-docs
           git diff --exit-code
+      - name: Build chart dependencies
+        run: helm dependency build n8n
       - name: Helm lint
         run: helm lint n8n
       - name: Helm lint with values

--- a/README.md
+++ b/README.md
@@ -489,6 +489,12 @@ pip install pre-commit
 pre-commit install
 ```
 
+When working with the chart from source make sure subchart dependencies are present:
+
+```bash
+helm dependency build n8n
+```
+
 The configured hook runs `helm-docs` and fails if documentation files change.
 Download the `helm-docs` binary and ensure it is available in your `PATH`:
 


### PR DESCRIPTION
## Summary
- build chart dependencies before linting so `helm template` works
- document building subchart dependencies when using repo

## Testing
- `pre-commit run --files README.md .github/workflows/lint.yaml`
- `helm template n8n`

------
https://chatgpt.com/codex/tasks/task_e_684ee4847854832aa1df7405200634a8