### PR TITLE
Mount cache volume for n8n

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: azure/setup-helm@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Build chart dependencies
+        run: helm dependency build n8n
       - name: Install helm-docs
         run: |
           curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this Helm chart will be documented in this file.
 ## [0.1.18] - 2025-06-15
 ### Fixed
 - Mount writable cache directory when running with a read-only root filesystem.
+- Fetch chart dependencies during CI lint workflow.
+- Document running `helm dependency build` before installing the chart.
 
 ## [0.1.15] - 2025-06-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this Helm chart will be documented in this file.
 ### Fixed
 - Safely access PostgreSQL secret keys to avoid nil pointer errors.
 
+## [0.1.18] - 2025-06-15
+### Fixed
+- Mount writable cache directory when running with a read-only root filesystem.
+
 ## [0.1.15] - 2025-06-15
 ### Fixed
 - Mount an emptyDir volume when persistence is disabled so pods start with a read-only filesystem.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ helm repo add n8n https://anyfavors.github.io/n8n-helm
 helm repo update
 
 # install the chart with the default values
+helm dependency build n8n
 helm install my-n8n n8n/n8n
 ```
 

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -223,8 +223,10 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | strategy.maxUnavailable | string | `"25%"` |  |
 | strategy.type | string | `"RollingUpdate"` |  |
 | tolerations | list | `[]` |  |
-| volumeMounts | list | `[]` |  |
-| volumes | list | `[]` |  |
+| volumeMounts[0].mountPath | string | `"/home/node/.cache"` |  |
+| volumeMounts[0].name | string | `"cache"` |  |
+| volumes[0].emptyDir | object | `{}` |  |
+| volumes[0].name | string | `"cache"` |  |
 | webhookUrl | string | `""` |  |
 
 ----------------------------------------------

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -154,6 +154,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n
+            - name: cache
+              mountPath: /home/node/.cache
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -162,6 +164,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n
+            - name: cache
+              mountPath: /home/node/.cache
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -175,6 +179,8 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ default (printf "%s-data" (include "n8n.fullname" .)) .Values.persistence.existingClaim }}
+        - name: cache
+          emptyDir: {}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -182,6 +188,8 @@ spec:
       {{- else }}
       volumes:
         - name: data
+          emptyDir: {}
+        - name: cache
           emptyDir: {}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/n8n/templates/statefulset.yaml
+++ b/n8n/templates/statefulset.yaml
@@ -138,6 +138,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n
+            - name: cache
+              mountPath: /home/node/.cache
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -155,6 +157,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n
+            - name: cache
+              mountPath: /home/node/.cache
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -177,6 +181,8 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ default (printf "%s-data" (include "n8n.fullname" .)) .Values.persistence.existingClaim }}
+        - name: cache
+          emptyDir: {}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -193,6 +199,8 @@ spec:
       {{- else }}
       volumes:
         - name: data
+          emptyDir: {}
+        - name: cache
           emptyDir: {}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/n8n/tests/webhook_test.yaml
+++ b/n8n/tests/webhook_test.yaml
@@ -1,0 +1,13 @@
+suite: webhook
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: sets webhook env when value provided
+    set:
+      webhookUrl: http://example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_WEBHOOK_URL
+            value: http://example.com

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -212,14 +212,18 @@ persistence:
   existingClaim: ""
 
 # Additional volumes on the output Deployment definition.
-volumes: []
+volumes:
+  - name: cache
+    emptyDir: {}
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
+volumeMounts:
+  - name: cache
+    mountPath: /home/node/.cache
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true


### PR DESCRIPTION
## Summary
- mount a writable cache volume for /home/node/.cache so n8n starts with read-only rootfs
- document chart version bump

## Testing
- `pre-commit run --files n8n/templates/deployment.yaml n8n/templates/statefulset.yaml n8n/values.yaml n8n/Chart.yaml CHANGELOG.md n8n/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684f006a91bc832ab832a3a65fa12ab5