### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,8 +509,6 @@ Run all checks manually with:
 pre-commit run --all-files
 ```
 
-=======
-
 ## Maintenance
 
 Automated dependency updates are handled by [Renovate](https://github.com/renovatebot/renovate).
@@ -519,7 +517,7 @@ GitHub Actions used in this repository and the Helm tooling versions referenced
 in the workflows. When a new version of the `helm-docs` plugin or a GitHub
 Action becomes available, Renovate opens a pull request with the update.
 Maintainers should review these PRs and merge them once the checks pass.
-=======
+ 
 ## Verifying chart signatures
 
 Chart packages are signed using [cosign](https://docs.sigstore.dev/cosign/overview/). The corresponding `cosign.pub` public key is attached to each GitHub release.

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -33,7 +33,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **generateEncryptionKey** – automatically create a secret with a random encryption key.
 - **generateDatabasePassword** – automatically create a secret with a random database password.
 - **webhookUrl** – external URL for webhook callbacks.
-- **extraEnv** – additional environment variables passed to the container.
+- **extraEnv** – additional environment variables passed to the container. Set
+  `N8N_RUNNERS_ENABLED=true` to enable task runners as recommended by n8n.
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **initContainers** – additional init containers executed before the main pod.

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -33,7 +33,8 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **generateEncryptionKey** – automatically create a secret with a random encryption key.
 - **generateDatabasePassword** – automatically create a secret with a random database password.
 - **webhookUrl** – external URL for webhook callbacks.
-- **extraEnv** – additional environment variables passed to the container.
+- **extraEnv** – additional environment variables passed to the container. Set
+  `N8N_RUNNERS_ENABLED=true` to enable task runners as recommended by n8n.
 - **extraSecrets** – mount additional Secrets inside the pod.
 - **extraConfigMaps** – mount additional ConfigMaps inside the pod.
 - **initContainers** – additional init containers executed before the main pod.

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -69,6 +69,8 @@ securityContext:
 extraEnv: []
 # - name: N8N_BASIC_AUTH_ACTIVE
 #   value: "true"
+# - name: N8N_RUNNERS_ENABLED
+#   value: "true"  # enable task runners
 
 # Connection details for an external PostgreSQL database. Leave values empty to
 # use the built-in SQLite storage.


### PR DESCRIPTION
## Summary
- remove stray `=======` separators

## Testing
- `pre-commit run --files README.md` *(fails: helm-docs command not found prior to install; after installing, fails due to non-empty git diff)*

------
https://chatgpt.com/codex/tasks/task_e_68505543044c832ab40b3da075d013e8