### PR TITLE
Enable n8n task runners by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this Helm chart will be documented in this file.
 
+## [0.1.19] - 2025-06-16
+### Added
+- Support for task runners via the `runners.enabled` value. Sets the `N8N_RUNNERS_ENABLED` environment variable.
+
+## [0.1.18] - 2025-06-15
+### Fixed
+- Mount writable cache directory when running with a read-only root filesystem.
+- Fetch chart dependencies during CI lint workflow.
+- Document running `helm dependency build` before installing the chart.
+
 ## [0.1.17] - 2025-06-15
 ### Added
 - Optional PostgreSQL database deployed via the Bitnami subchart.
@@ -11,12 +21,6 @@ All notable changes to this Helm chart will be documented in this file.
 
 ### Fixed
 - Safely access PostgreSQL secret keys to avoid nil pointer errors.
-
-## [0.1.18] - 2025-06-15
-### Fixed
-- Mount writable cache directory when running with a read-only root filesystem.
-- Fetch chart dependencies during CI lint workflow.
-- Document running `helm dependency build` before installing the chart.
 
 ## [0.1.15] - 2025-06-15
 ### Fixed

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -32,6 +32,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
 - **generateEncryptionKey** – automatically create a secret with a random encryption key.
 - **generateDatabasePassword** – automatically create a secret with a random database password.
+- **runners.enabled** – enable task runners to process executions.
 - **webhookUrl** – external URL for webhook callbacks.
 - **extraEnv** – additional environment variables passed to the container.
 - **extraSecrets** – mount additional Secrets inside the pod.
@@ -208,6 +209,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | resources.limits.memory | string | `"512Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"256Mi"` |  |
+| runners.enabled | bool | `true` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -32,6 +32,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
 - **generateEncryptionKey** – automatically create a secret with a random encryption key.
 - **generateDatabasePassword** – automatically create a secret with a random database password.
+- **runners.enabled** – enable task runners to process executions.
 - **webhookUrl** – external URL for webhook callbacks.
 - **extraEnv** – additional environment variables passed to the container.
 - **extraSecrets** – mount additional Secrets inside the pod.

--- a/n8n/templates/deployment.yaml
+++ b/n8n/templates/deployment.yaml
@@ -69,7 +69,8 @@ spec:
           {{- $secret := ternary (dict "name" (printf "%s-db-password" (include "n8n.fullname" .)) "key" "password") $db.passwordSecret .Values.generateDatabasePassword }}
           {{- $enc := ternary (dict "name" (printf "%s-encryption-key" (include "n8n.fullname" .)) "key" "encryptionKey") .Values.encryptionKeySecret .Values.generateEncryptionKey }}
           {{- $webhook := .Values.webhookUrl }}
-          {{- if or $db.host $db.port $db.user $db.password $db.passwordSecret.name $secret.name $db.database $pg.enabled $enc.name $webhook (gt (len .Values.extraEnv) 0) }}
+          {{- $runners := .Values.runners }}
+          {{- if or $db.host $db.port $db.user $db.password $db.passwordSecret.name $secret.name $db.database $pg.enabled $enc.name $webhook $runners.enabled (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if $webhook }}
             - name: N8N_WEBHOOK_URL
@@ -119,6 +120,10 @@ spec:
                 secretKeyRef:
                   name: {{ $enc.name }}
                   key: {{ $enc.key | default "encryptionKey" }}
+            {{- end }}
+            {{- if $runners.enabled }}
+            - name: N8N_RUNNERS_ENABLED
+              value: "{{ $runners.enabled }}"
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/n8n/templates/statefulset.yaml
+++ b/n8n/templates/statefulset.yaml
@@ -53,7 +53,8 @@ spec:
           {{- $secret := ternary (dict "name" (printf "%s-db-password" (include "n8n.fullname" .)) "key" "password") $db.passwordSecret .Values.generateDatabasePassword }}
           {{- $enc := ternary (dict "name" (printf "%s-encryption-key" (include "n8n.fullname" .)) "key" "encryptionKey") .Values.encryptionKeySecret .Values.generateEncryptionKey }}
           {{- $webhook := .Values.webhookUrl }}
-          {{- if or $db.host $db.port $db.user $db.password $db.passwordSecret.name $secret.name $db.database $pg.enabled $enc.name $webhook (gt (len .Values.extraEnv) 0) }}
+          {{- $runners := .Values.runners }}
+          {{- if or $db.host $db.port $db.user $db.password $db.passwordSecret.name $secret.name $db.database $pg.enabled $enc.name $webhook $runners.enabled (gt (len .Values.extraEnv) 0) }}
           env:
             {{- if $webhook }}
             - name: N8N_WEBHOOK_URL
@@ -103,6 +104,10 @@ spec:
                 secretKeyRef:
                   name: {{ $enc.name }}
                   key: {{ $enc.key | default "encryptionKey" }}
+            {{- end }}
+            {{- if $runners.enabled }}
+            - name: N8N_RUNNERS_ENABLED
+              value: "{{ $runners.enabled }}"
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -374,6 +374,14 @@
                 }
             }
         },
+        "runners": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "securityContext": {
             "type": "object",
             "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -106,6 +106,10 @@ generateDatabasePassword: false
 webhookUrl: ""
 # webhookUrl: https://my-n8n.example.com/
 
+# Enable n8n task runners
+runners:
+  enabled: true
+
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types


### PR DESCRIPTION
## Summary
- add `runners.enabled` value and document it
- set `N8N_RUNNERS_ENABLED` env var in templates
- bump chart version to 0.1.19
- update generated docs and changelog

## Testing
- `pre-commit run --files n8n/values.yaml n8n/README.md.gotmpl n8n/Chart.yaml n8n/values.schema.json CHANGELOG.md n8n/templates/deployment.yaml n8n/templates/statefulset.yaml n8n/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68505ce456a0832a8718feed36f392d1