### PR TITLE
Fix PDB template conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ helm install my-n8n n8n/n8n \
   --set pdb.minAvailable=1
 ```
 
+Only one of `pdb.minAvailable` or `pdb.maxUnavailable` should be set. If both
+are configured neither will be applied.
+
 
 ## Role-based access control
 

--- a/n8n/templates/pdb.yaml
+++ b/n8n/templates/pdb.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.pdb.minAvailable }}
+  {{- if and .Values.pdb.minAvailable (not .Values.pdb.maxUnavailable) }}
   minAvailable: {{ .Values.pdb.minAvailable }}
   {{- end }}
-  {{- if .Values.pdb.maxUnavailable }}
+  {{- if and .Values.pdb.maxUnavailable (not .Values.pdb.minAvailable) }}
   maxUnavailable: {{ .Values.pdb.maxUnavailable }}
   {{- end }}
   selector:

--- a/n8n/tests/pdb_test.yaml
+++ b/n8n/tests/pdb_test.yaml
@@ -15,6 +15,8 @@ tests:
       - equal:
           path: spec.minAvailable
           value: 1
+      - notExists:
+          path: spec.maxUnavailable
   - it: sets maxUnavailable when configured
     set:
       pdb:
@@ -24,3 +26,16 @@ tests:
       - equal:
           path: spec.maxUnavailable
           value: 1
+      - notExists:
+          path: spec.minAvailable
+  - it: does not render when both are configured
+    set:
+      pdb:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+    asserts:
+      - notExists:
+          path: spec.minAvailable
+      - notExists:
+          path: spec.maxUnavailable


### PR DESCRIPTION
## Summary
- fix logic to only render one of PDB `minAvailable` or `maxUnavailable`
- warn in documentation to only set one value
- update unit tests for the new behaviour

## Testing
- `helm-docs`
- `helm lint n8n`
- `helm lint n8n --values n8n/values.yaml`
- `helm unittest n8n`
- `helm schema-gen n8n/values.yaml > generated-values.schema.json`
- `diff -u n8n/values.schema.json generated-values.schema.json` *(no output)*
- `helm template n8n` *(fails: found in Chart.yaml, but missing in charts/ directory: postgresql)*

------
https://chatgpt.com/codex/tasks/task_e_6851470370f0832ab3a0a34b53f24e8a