### PR TITLE
Add secret generation tests

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -155,7 +155,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | extraSecrets | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | generateDatabasePassword | bool | `false` |  |
-| generateEncryptionKey | bool | `true` |  |
+| generateEncryptionKey | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"n8nio/n8n"` |  |
 | image.tag | string | `"1.98.1"` |  |

--- a/n8n/tests/secret_test.yaml
+++ b/n8n/tests/secret_test.yaml
@@ -1,0 +1,22 @@
+suite: secrets
+templates:
+  - templates/secret.yaml
+tests:
+  - it: is not rendered by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders db password secret when enabled
+    set:
+      generateDatabasePassword: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-n8n-db-password
+  - it: renders encryption key secret when enabled
+    set:
+      generateEncryptionKey: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-n8n-encryption-key

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -99,7 +99,7 @@ encryptionKeySecret:
   key: encryptionKey
 
 # Generate a secret containing a random N8N_ENCRYPTION_KEY
-generateEncryptionKey: true
+generateEncryptionKey: false
 
 # Generate a secret containing a random database password
 generateDatabasePassword: false


### PR DESCRIPTION
## Summary
- add new tests for secret creation
- disable encryption key generation by default
- update docs

## Testing
- `helm unittest ./n8n`

------
https://chatgpt.com/codex/tasks/task_e_6851607a4b98832a93538cd4354a5854