### PR TITLE
Improve schema check in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,8 @@ repos:
         entry: bash -c 'helm-docs && git diff --exit-code'
         language: system
         pass_filenames: false
+      - id: helm-schema
+        name: helm-values-schema
+        entry: bash -c 'helm schema-gen n8n/values.yaml > generated-values.schema.json && diff -u n8n/values.schema.json generated-values.schema.json'
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -525,6 +525,9 @@ Download the `helm-docs` binary and ensure it is available in your `PATH`:
 ```bash
 curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz | tar -xz -C /usr/local/bin helm-docs
 ```
+The pre-commit hooks also verify that `values.schema.json` matches the schema
+generated from `values.yaml`. Install the `helm-schema-gen` plugin so the check
+can run locally.
 Verify the chart locally with the same commands used in CI:
 
 ```bash


### PR DESCRIPTION
## Summary
- add helm-schema-gen step to pre-commit
- document that the hook verifies the generated values schema

## Testing
- `helm lint n8n`
- `helm unittest n8n`


------
https://chatgpt.com/codex/tasks/task_e_685162e6667c832a8d5ebf341e220047