### PR TITLE
Improve helm chart testing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,12 +528,12 @@ curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-d
 The pre-commit hooks also verify that `values.schema.json` matches the schema
 generated from `values.yaml`. Install the `helm-schema-gen` plugin so the check
 can run locally.
-Verify the chart locally with the same commands used in CI:
+Verify the chart locally with the same commands used in CI. The provided
+`scripts/run-tests.sh` helper installs missing dependencies, builds the chart
+dependencies and runs the lint and unit tests:
 
 ```bash
-helm dependency build n8n
-helm lint n8n
-helm unittest n8n
+./scripts/run-tests.sh
 ```
 
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="$(dirname "$0")/../n8n"
+
+if ! command -v helm >/dev/null; then
+  echo "helm is required but not installed" >&2
+  exit 1
+fi
+
+# Install helm-unittest plugin if missing
+if ! helm plugin list | grep -q '^unittest'; then
+  echo "Installing helm-unittest plugin" >&2
+  helm plugin install https://github.com/helm-unittest/helm-unittest >/dev/null
+fi
+
+# Add bitnami repo for postgresql dependency
+if ! helm repo list | grep -q "bitnami"; then
+  helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null
+fi
+helm repo update >/dev/null
+
+# Build chart dependencies
+helm dependency build "$CHART_DIR" >/dev/null
+
+# Lint and unit test chart
+helm lint "$CHART_DIR"
+helm unittest "$CHART_DIR"
+
+# Validate schema is up to date
+if helm plugin list | grep -q helm-schema; then
+  helm schema-gen "$CHART_DIR"/values.yaml > /tmp/generated-values.schema.json
+  diff -u "$CHART_DIR"/values.schema.json /tmp/generated-values.schema.json
+fi
+
+# Render templates to ensure they compile
+helm template "$CHART_DIR" >/dev/null
+


### PR DESCRIPTION
## Summary
- add a helper script to run chart tests
- mention script in README

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851649591c4832ab80226f9c92a2ca4