### PR TITLE
Fix repo update failure handling

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -19,7 +19,7 @@ fi
 
 # Add bitnami repo for postgresql dependency
 helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null 2>&1 || true
-helm repo update >/dev/null
+helm repo update >/dev/null || true
 
 # Build chart dependencies
 helm dependency build "$CHART_DIR" >/dev/null


### PR DESCRIPTION
## Summary
- allow `helm repo update` to fail without stopping tests

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68518ac17168832a9ea6d9b9d4d1df8e