### PR TITLE
Add statefulset count test

### DIFF
--- a/n8n/tests/statefulset_test.yaml
+++ b/n8n/tests/statefulset_test.yaml
@@ -6,6 +6,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: renders one statefulset when persistence enabled
+    set:
+      persistence:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
   - it: mounts existing pvc when configured
     set:
       persistence:


### PR DESCRIPTION
## Summary
- ensure statefulset renders exactly one document when persistence is enabled

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68519c4fe220832a8dace67d31167a21