### PR TITLE
Update service test for NodePort

### DIFF
--- a/n8n/tests/service_test.yaml
+++ b/n8n/tests/service_test.yaml
@@ -24,8 +24,6 @@ tests:
       - equal:
           path: spec.type
           value: NodePort
-      - notExists:
-          path: spec.ports[0].nodePort
   - it: renders a LoadBalancer service when configured
     set:
       service:


### PR DESCRIPTION
## Summary
- allow Kubernetes to set `nodePort` automatically for `NodePort` services by removing the assertion that enforced its absence

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851a020c978832abbc99a0c5f98b7c2