### PR TITLE
Use hook job to label namespace

### DIFF
--- a/n8n/templates/podsecurity.yaml
+++ b/n8n/templates/podsecurity.yaml
@@ -1,18 +1,28 @@
 {{- if or .Values.podSecurity.enforce .Values.podSecurity.audit .Values.podSecurity.warn }}
 ---
-apiVersion: v1
-kind: Namespace
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: {{ .Release.Namespace }}
+  name: {{ include "n8n.fullname" . }}-podsecurity
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- if .Values.podSecurity.enforce }}
-    pod-security.kubernetes.io/enforce: {{ .Values.podSecurity.enforce | quote }}
-    {{- end }}
-    {{- if .Values.podSecurity.audit }}
-    pod-security.kubernetes.io/audit: {{ .Values.podSecurity.audit | quote }}
-    {{- end }}
-    {{- if .Values.podSecurity.warn }}
-    pod-security.kubernetes.io/warn: {{ .Values.podSecurity.warn | quote }}
-    {{- end }}
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "n8n.serviceAccountName" . }}
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - >-
+              kubectl label --overwrite namespace {{ .Release.Namespace }}
+              {{- if .Values.podSecurity.enforce }} pod-security.kubernetes.io/enforce={{ .Values.podSecurity.enforce }}{{- end }}
+              {{- if .Values.podSecurity.audit }} pod-security.kubernetes.io/audit={{ .Values.podSecurity.audit }}{{- end }}
+              {{- if .Values.podSecurity.warn }} pod-security.kubernetes.io/warn={{ .Values.podSecurity.warn }}{{- end }}
 {{- end }}
 

--- a/n8n/tests/podsecurity_test.yaml
+++ b/n8n/tests/podsecurity_test.yaml
@@ -15,13 +15,16 @@ tests:
     asserts:
       - equal:
           path: kind
-          value: Namespace
+          value: Job
       - equal:
-          path: metadata.labels["pod-security.kubernetes.io/enforce"]
-          value: restricted
-      - equal:
-          path: metadata.labels["pod-security.kubernetes.io/audit"]
-          value: restricted
-      - equal:
-          path: metadata.labels["pod-security.kubernetes.io/warn"]
-          value: restricted
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: pod-security.kubernetes.io/enforce=restricted
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: pod-security.kubernetes.io/audit=restricted
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: pod-security.kubernetes.io/warn=restricted


### PR DESCRIPTION
## Summary
- avoid creating a Namespace in `podsecurity.yaml`
- label the existing namespace with a pre-install/pre-upgrade hook job
- update podsecurity unit test

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851ac43cb50832aab650df5f0120680