### PR TITLE
Disable network policy by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,9 @@ The chart also includes a `values.schema.json` file that defines the allowed str
 
 ## Network policies
 
-`networkPolicy.enabled` defaults to `true`, creating a `NetworkPolicy` that
-denies all ingress and egress traffic. Extend the policy under
+`networkPolicy.enabled` defaults to `false`. Enable it to create a `NetworkPolicy`
+that denies all ingress and egress traffic. Extend the policy under
 `networkPolicy.ingress` and `networkPolicy.egress` to permit connections.
-Disable the policy entirely by setting `networkPolicy.enabled=false`.
 
 To allow specific traffic, extend the policy in your values file:
 

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -24,7 +24,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume using a StatefulSet.
 - **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
-- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (enabled by default).
+- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (disabled by default).
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
@@ -121,6 +121,24 @@ extraContainers:
     command: ["sh", "-c", "echo sidecar"]
 ```
 
+## Network policy example
+
+Enable `networkPolicy` to restrict traffic and define ingress/egress rules:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: my-namespace
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+```
+
 ## Publishing
 
 Chart packages are created automatically using [chart-releaser](https://github.com/helm/chart-releaser) when commits land on `main`.
@@ -176,7 +194,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | metrics.serviceMonitor.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | networkPolicy.egress | list | `[]` |  |
-| networkPolicy.enabled | bool | `true` |  |
+| networkPolicy.enabled | bool | `false` |  |
 | networkPolicy.ingress | list | `[]` |  |
 | networkPolicy.policyTypes[0] | string | `"Ingress"` |  |
 | networkPolicy.policyTypes[1] | string | `"Egress"` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -24,7 +24,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume using a StatefulSet.
 - **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
-- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (enabled by default).
+- **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (disabled by default).
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
@@ -120,6 +120,24 @@ extraContainers:
   - name: sidecar
     image: busybox
     command: ["sh", "-c", "echo sidecar"]
+```
+
+## Network policy example
+
+Enable `networkPolicy` to restrict traffic and define ingress/egress rules:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: my-namespace
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
 ```
 
 ## Publishing

--- a/n8n/tests/networkpolicy_test.yaml
+++ b/n8n/tests/networkpolicy_test.yaml
@@ -2,6 +2,10 @@ suite: network policy
 templates:
   - templates/networkpolicy.yaml
 tests:
+  - it: is not rendered by default
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: is not rendered when disabled
     set:
       networkPolicy:

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -147,7 +147,7 @@ ingress:
   #      - chart-example.local
 
 networkPolicy:
-  enabled: true
+  enabled: false
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
## Summary
- disable network policy by default in values
- document how to enable a network policy and customise rules
- expect no network policy to be generated unless enabled

## Testing
- `pre-commit run --files README.md n8n/README.md n8n/README.md.gotmpl n8n/tests/networkpolicy_test.yaml n8n/values.yaml`
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851ae92dfd0832a93ab8d00078cf62a