### PR TITLE
Add metrics path to ServiceMonitor

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -191,6 +191,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | livenessProbe.httpGet.port | string | `"http"` |  |
 | metrics.enabled | bool | `false` |  |
 | metrics.port | int | `5678` |  |
+| metrics.path | string | `"/metrics"` |  |
 | metrics.serviceMonitor.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | networkPolicy.egress | list | `[]` |  |

--- a/n8n/templates/servicemonitor.yaml
+++ b/n8n/templates/servicemonitor.yaml
@@ -12,4 +12,5 @@ spec:
       {{- include "n8n.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: metrics
+      path: {{ .Values.metrics.path }}
 {{- end }}

--- a/n8n/tests/servicemonitor_test.yaml
+++ b/n8n/tests/servicemonitor_test.yaml
@@ -19,3 +19,6 @@ tests:
       - equal:
           path: spec.endpoints[0].port
           value: metrics
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -192,6 +192,9 @@
                 "port": {
                     "type": "integer"
                 },
+                "path": {
+                    "type": "string"
+                },
                 "serviceMonitor": {
                     "type": "object",
                     "properties": {

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -126,6 +126,8 @@ metrics:
   enabled: false
   # Port for the metrics service
   port: 5678
+  # HTTP path to scrape metrics
+  path: /metrics
   serviceMonitor:
     enabled: false
 


### PR DESCRIPTION
## Summary
- expose metrics path in values
- set ServiceMonitor endpoint path
- document metrics.path in README
- update ServiceMonitor unit test

## Testing
- `bash scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851b0d0cb84832a9a5517e618033beb