### PR TITLE
Update network policy examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,19 @@ networkPolicy:
       ports:
         - protocol: TCP
           port: 5678
-  egress: []
+  egress:
+    # allow the application to connect to the PostgreSQL service
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgres
+      ports:
+        - protocol: TCP
+          port: 5432
 ```
+
+Egress rules are required because enabling the policy blocks all outbound
+traffic. Without them the pod cannot reach external services like the database.
 
 ## Pod Security Standards
 

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -136,10 +136,19 @@ networkPolicy:
             matchLabels:
               name: my-namespace
   egress:
+    # allow connections to the PostgreSQL database service
     - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
+        - podSelector:
+            matchLabels:
+              app: postgres
+      ports:
+        - protocol: TCP
+          port: 5432
 ```
+
+When network policies are enabled all outbound traffic is denied. Define egress
+rules for any external services—such as your database—so the application can
+reach them.
 
 ## Publishing
 


### PR DESCRIPTION
## Summary
- document how to allow egress to a database service
- clarify why egress rules are needed

## Testing
- `./scripts/run-tests.sh` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685259526c24832ab6e44d2d7da83f48