### PR TITLE
Add kubeVersion metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this Helm chart will be documented in this file.
 
+## [0.1.21] - 2025-06-18
+### Added
+- Specify supported Kubernetes versions in `Chart.yaml`.
+
 ## [0.1.20] - 2025-06-17
 ### Added
 - Chart icon in `Chart.yaml` for improved metadata.

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -16,11 +16,12 @@ maintainers:
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
+kubeVersion: ">=1.21.0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.20
+version: 0.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Summary
- add `kubeVersion` to `Chart.yaml`
- bump chart version to 0.1.21
- document minimum supported Kubernetes version in CHANGELOG

## Testing
- `./scripts/run-tests.sh` *(fails: could not download postgresql dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68525cb820a8832aacc08cd08214c8cc