### PR TITLE
Enable encryption key secret by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this Helm chart will be documented in this file.
 
+## [0.1.22] - 2025-06-19
+### Changed
+- Generate encryption key secret by default.
+
 ## [0.1.21] - 2025-06-18
 ### Added
 - Specify supported Kubernetes versions in `Chart.yaml`.

--- a/README.md
+++ b/README.md
@@ -449,7 +449,9 @@ repository.
 
 ## Credential encryption
 
-Generate a 256‑bit key and store it in a secret to encrypt credentials:
+The chart now generates a secret containing a random encryption key by default.
+Disable this behaviour by setting `generateEncryptionKey=false`.
+To supply your own key, create a secret containing a 256‑bit value:
 
 ```bash
 kubectl create secret generic n8n-key \

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -184,7 +184,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | extraSecrets | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | generateDatabasePassword | bool | `false` |  |
-| generateEncryptionKey | bool | `false` |  |
+| generateEncryptionKey | bool | `true` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"n8nio/n8n"` |  |
 | image.tag | string | `"1.99.0"` |  |

--- a/n8n/tests/secret_test.yaml
+++ b/n8n/tests/secret_test.yaml
@@ -2,13 +2,17 @@ suite: secrets
 templates:
   - templates/secret.yaml
 tests:
-  - it: is not rendered by default
+  - it: renders encryption key secret by default
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-n8n-encryption-key
   - it: renders db password secret when enabled
     set:
       generateDatabasePassword: true
+    documentIndex: 0
     asserts:
       - equal:
           path: metadata.name
@@ -16,6 +20,7 @@ tests:
   - it: renders encryption key secret when enabled
     set:
       generateEncryptionKey: true
+    documentIndex: 0
     asserts:
       - equal:
           path: metadata.name

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -99,7 +99,7 @@ encryptionKeySecret:
   key: encryptionKey
 
 # Generate a secret containing a random N8N_ENCRYPTION_KEY
-generateEncryptionKey: false
+generateEncryptionKey: true
 
 # Generate a secret containing a random database password
 generateDatabasePassword: false


### PR DESCRIPTION
## Summary
- default `generateEncryptionKey` to `true`
- adjust secret unit tests
- document automatic encryption key secret generation
- note the change in the changelog

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852749758e8832aa1a08ea4c15cb4cc