### PR TITLE
Fix serviceAccount creation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ are configured neither will be applied.
 
 ## Role-based access control
 
-Enable creation of a Role and RoleBinding for the service account by setting `rbac.create`:
+Enable creation of a Role and RoleBinding for the service account by setting `rbac.create`.
+The chart will only create the ServiceAccount when both `rbac.create` and `serviceAccount.create` are enabled:
 
 ```bash
 helm install my-n8n n8n/n8n \

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -28,6 +28,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (disabled by default).
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
+- **serviceAccount.create** – create a ServiceAccount when `rbac.create` is enabled.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **postgresql.enabled** – deploy a PostgreSQL database as part of the release.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -29,6 +29,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (disabled by default).
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
+- **serviceAccount.create** – create a ServiceAccount when `rbac.create` is enabled.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **postgresql.enabled** – deploy a PostgreSQL database as part of the release.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.

--- a/n8n/templates/_helpers.tpl
+++ b/n8n/templates/_helpers.tpl
@@ -61,7 +61,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "n8n.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if and .Values.serviceAccount.create .Values.rbac.create }}
 {{- default (include "n8n.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/n8n/templates/serviceaccount.yaml
+++ b/n8n/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.serviceAccount.create .Values.rbac.create -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/n8n/tests/serviceaccount_test.yaml
+++ b/n8n/tests/serviceaccount_test.yaml
@@ -2,12 +2,15 @@ suite: serviceaccount
 templates:
   - templates/serviceaccount.yaml
 tests:
-  - it: disables automount by default
+  - it: disables automount when rbac enabled
+    set:
+      rbac:
+        create: true
     asserts:
       - equal:
           path: automountServiceAccountToken
           value: false
-  - it: overrides name when rbac disabled
+  - it: is not rendered when rbac disabled
     set:
       rbac:
         create: false
@@ -15,6 +18,5 @@ tests:
         create: true
         name: custom-sa
     asserts:
-      - equal:
-          path: metadata.name
-          value: custom-sa
+      - hasDocuments:
+          count: 0

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -21,7 +21,7 @@ fullnameOverride: ""
 
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
-  # Specifies whether a service account should be created
+  # Specifies whether a service account should be created when rbac.create is true
   create: true
   # Automatically mount a ServiceAccount's API credentials?
   automount: false
@@ -31,7 +31,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# Toggle creation of Role and RoleBinding resources
+# Toggle creation of Role, RoleBinding and ServiceAccount resources
 rbac:
   create: false
 


### PR DESCRIPTION
## Summary
- create ServiceAccount only when both `rbac.create` and `serviceAccount.create` are enabled
- clarify this behaviour in values.yaml and README documentation
- update helper template and unit tests

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68527a3f0464832a8d6084c1729a87ed