### PR TITLE
Check helm tools availability in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ repos:
     hooks:
       - id: helm-docs
         name: helm-docs
-        entry: bash -c 'helm-docs && git diff --exit-code'
+        entry: bash scripts/pre-commit-helm-docs.sh
         language: system
         pass_filenames: false
       - id: helm-schema
         name: helm-values-schema
-        entry: bash -c 'helm schema-gen n8n/values.yaml > generated-values.schema.json && diff -u n8n/values.schema.json generated-values.schema.json'
+        entry: bash scripts/pre-commit-helm-schema.sh
         language: system
         pass_filenames: false

--- a/scripts/pre-commit-helm-docs.sh
+++ b/scripts/pre-commit-helm-docs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v helm-docs >/dev/null 2>&1; then
+  echo "Error: helm-docs command not found." >&2
+  echo "Install helm-docs from https://github.com/norwoodj/helm-docs/releases and ensure it is in your PATH." >&2
+  exit 1
+fi
+
+helm-docs
+
+git diff --exit-code

--- a/scripts/pre-commit-helm-schema.sh
+++ b/scripts/pre-commit-helm-schema.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="n8n"
+SCHEMA_FILE="generated-values.schema.json"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "Error: helm command not found." >&2
+  exit 1
+fi
+
+# Check for schema-gen plugin
+if ! helm plugin list | grep -q '^schema-gen'; then
+  echo "Error: helm schema-gen plugin not installed." >&2
+  echo "Install with: helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git" >&2
+  exit 1
+fi
+
+helm schema-gen "$CHART_DIR/values.yaml" > "$SCHEMA_FILE"
+diff -u "$CHART_DIR/values.schema.json" "$SCHEMA_FILE"


### PR DESCRIPTION
## Summary
- add helper scripts used by pre-commit hooks
- update `.pre-commit-config.yaml` to call helper scripts
- helper scripts fail with clear messages if helm-docs or helm schema-gen is missing

## Testing
- `pre-commit run --files scripts/pre-commit-helm-docs.sh scripts/pre-commit-helm-schema.sh .pre-commit-config.yaml` *(fails: helm-docs command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527bbe79a4832abcb574de74c8eea4