### PR TITLE
Add metrics annotations support

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -191,6 +191,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | lifecycle | object | `{}` |  |
 | livenessProbe.httpGet.path | string | `"/"` |  |
 | livenessProbe.httpGet.port | string | `"http"` |  |
+| metrics.annotations | object | `{}` |  |
 | metrics.enabled | bool | `false` |  |
 | metrics.path | string | `"/metrics"` |  |
 | metrics.port | int | `5678` |  |

--- a/n8n/templates/service-metrics.yaml
+++ b/n8n/templates/service-metrics.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "n8n.fullname" . }}-metrics
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.metrics.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/n8n/tests/service_metrics_test.yaml
+++ b/n8n/tests/service_metrics_test.yaml
@@ -17,3 +17,13 @@ tests:
       - equal:
           path: spec.ports[0].port
           value: 5678
+  - it: injects annotations when provided
+    set:
+      metrics:
+        enabled: true
+        annotations:
+          scrape: yes
+    asserts:
+      - equal:
+          path: metadata.annotations.scrape
+          value: "yes"

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -186,14 +186,17 @@
         "metrics": {
             "type": "object",
             "properties": {
+                "annotations": {
+                    "type": "object"
+                },
                 "enabled": {
                     "type": "boolean"
                 },
-                "port": {
-                    "type": "integer"
-                },
                 "path": {
                     "type": "string"
+                },
+                "port": {
+                    "type": "integer"
                 },
                 "serviceMonitor": {
                     "type": "object",

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -130,6 +130,8 @@ metrics:
   port: 5678
   # HTTP path to scrape metrics
   path: /metrics
+  # Annotations to add to the metrics service
+  annotations: {}
   serviceMonitor:
     enabled: false
 


### PR DESCRIPTION
## Summary
- add `metrics.annotations` map in values.yaml
- render annotations in metrics service template
- document new field
- add unit test for metrics annotations

## Testing
- `bash scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685287facd60832a96ba591cbf6aa3fc