### PR TITLE
Add service session affinity option

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -29,6 +29,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
 - **serviceAccount.create** – create a ServiceAccount when `rbac.create` is enabled.
+- **service.sessionAffinity** – session affinity policy for the service.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **postgresql.enabled** – deploy a PostgreSQL database as part of the release.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.
@@ -239,6 +240,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | securityContext.runAsNonRoot | bool | `true` |  |
 | service.annotations | object | `{}` |  |
 | service.port | int | `5678` |  |
+| service.sessionAffinity | string | `"None"` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automount | bool | `false` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -30,6 +30,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
 - **serviceAccount.create** – create a ServiceAccount when `rbac.create` is enabled.
+- **service.sessionAffinity** – session affinity policy for the service.
 - **database.host** – connect to an external PostgreSQL database instead of the built in SQLite storage.
 - **postgresql.enabled** – deploy a PostgreSQL database as part of the release.
 - **encryptionKeySecret.name** – Kubernetes secret providing `N8N_ENCRYPTION_KEY`.

--- a/n8n/templates/service.yaml
+++ b/n8n/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.sessionAffinity }}
+  sessionAffinity: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/n8n/tests/service_test.yaml
+++ b/n8n/tests/service_test.yaml
@@ -7,6 +7,9 @@ tests:
       - equal:
           path: spec.type
           value: ClusterIP
+      - equal:
+          path: spec.sessionAffinity
+          value: None
   - it: injects annotations when provided
     set:
       service:
@@ -32,3 +35,18 @@ tests:
       - equal:
           path: spec.type
           value: LoadBalancer
+  - it: renders custom session affinity when configured
+    set:
+      service:
+        sessionAffinity: ClientIP
+    asserts:
+      - equal:
+          path: spec.sessionAffinity
+          value: ClientIP
+  - it: omits session affinity when blank
+    set:
+      service:
+        sessionAffinity: ""
+    asserts:
+      - notExists:
+          path: spec.sessionAffinity

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -433,6 +433,9 @@
                 "port": {
                     "type": "integer"
                 },
+                "sessionAffinity": {
+                    "type": "string"
+                },
                 "type": {
                     "type": "string"
                 }

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -122,6 +122,8 @@ service:
   port: 5678
   # Annotations to add to the service
   annotations: {}
+  # Session affinity for the service
+  sessionAffinity: None
 
 # Expose Prometheus metrics on a dedicated service
 metrics:


### PR DESCRIPTION
## Summary
- add `service.sessionAffinity` option
- template the option into service spec
- document session affinity setting
- test session affinity behavior

## Testing
- `bash scripts/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68528dc5d9a0832aa5893c869caa483d