### PR TITLE
Add configurable PVC access modes

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -25,6 +25,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume using a StatefulSet.
 - **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
+- **persistence.accessModes** – list of access modes for the persistent volume claim.
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (disabled by default).
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.
@@ -205,6 +206,7 @@ Users can then add <https://anyfavors.github.io/n8n-helm> as a Helm repository t
 | networkPolicy.policyTypes[1] | string | `"Egress"` |  |
 | nodeSelector | object | `{}` |  |
 | pdb.enabled | bool | `false` |  |
+| persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | persistence.enabled | bool | `false` |  |
 | persistence.existingClaim | string | `""` |  |
 | persistence.size | string | `"8Gi"` |  |

--- a/n8n/README.md.gotmpl
+++ b/n8n/README.md.gotmpl
@@ -26,6 +26,7 @@ Customise the deployment by supplying your own `values.yaml` or overriding setti
 - **ingress.enabled** – expose the service using an ingress resource.
 - **persistence.enabled** – store workflows on a persistent volume using a StatefulSet.
 - **persistence.existingClaim** – mount an existing PersistentVolumeClaim.
+- **persistence.accessModes** – list of access modes for the persistent volume claim.
 - **networkPolicy.enabled** – create a NetworkPolicy to restrict traffic (disabled by default).
 - **pdb.enabled** – create a PodDisruptionBudget for the deployment.
 - **rbac.create** – create Role and RoleBinding resources.

--- a/n8n/templates/pvc.yaml
+++ b/n8n/templates/pvc.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "n8n.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+  {{- range .Values.persistence.accessModes }}
+    - {{ . }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size }}

--- a/n8n/tests/persistence_test.yaml
+++ b/n8n/tests/persistence_test.yaml
@@ -19,6 +19,9 @@ tests:
       - equal:
           path: spec.resources.requests.storage
           value: 5Gi
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
   - it: skips creation when existing claim is provided
     set:
       persistence:
@@ -36,3 +39,17 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: renders multiple access modes
+    set:
+      persistence:
+        enabled: true
+        accessModes:
+          - ReadWriteOnce
+          - ReadOnlyMany
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.accessModes[1]
+          value: ReadOnlyMany

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -245,6 +245,12 @@
         "persistence": {
             "type": "object",
             "properties": {
+                "accessModes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "enabled": {
                     "type": "boolean"
                 },

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -224,6 +224,9 @@ persistence:
   size: 8Gi
   storageClass: ""
   existingClaim: ""
+  # Access modes for the persistent volume claim
+  accessModes:
+    - ReadWriteOnce
 
 # Additional volumes on the output Deployment definition.
 volumes: []


### PR DESCRIPTION
## Summary
- expose `persistence.accessModes` in `values.yaml`
- render the list of access modes in `pvc.yaml`
- document the new option and generate docs
- expand persistence unit tests

## Testing
- `bash ./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685290a2bf24832a8fd3432ea1c5907e