### PR TITLE
Update database password secret docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,9 @@ directly to the connection fields:
 - `database.passwordSecret.key` – key within the secret (defaults to `password`)
 - `database.database` – name of the database to connect to
 
+When referencing a secret for the database password, ensure the secret includes
+the key specified by `database.passwordSecret.key` (default `password`).
+
 n8n requires a couple of additional environment variables when connecting to
 PostgreSQL. The chart populates them automatically when an external database is
 configured or the bundled PostgreSQL subchart is enabled:

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -79,7 +79,8 @@ database:
   port: 5432
   user: ""
   password: ""
-  # Reference an existing secret for the password instead of setting it directly
+  # Reference an existing secret for the password instead of setting it directly.
+  # The secret must include the key defined below (defaults to "password").
   passwordSecret:
     name: ""
     key: "password"


### PR DESCRIPTION
## Summary
- clarify README: mention that the secret needs the key defined by `database.passwordSecret.key`
- document same note in `values.yaml` comments

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685292785180832aab6c81a4d885ec4b