### PR TITLE
Restrict pathType values in schema

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,6 +46,8 @@ jobs:
       - name: Validate values schema
         run: |
           helm schema-gen n8n/values.yaml > generated-values.schema.json
+          jq --indent 4 '.properties.ingress.properties.hosts.items.properties.paths.items.properties.pathType += {"enum": ["ImplementationSpecific", "Prefix", "Exact"]}' generated-values.schema.json > tmp.json
+          mv tmp.json generated-values.schema.json
           diff -u n8n/values.schema.json generated-values.schema.json
       - name: Get chart version
         id: chart

--- a/n8n/values.schema.json
+++ b/n8n/values.schema.json
@@ -148,7 +148,12 @@
                                             "type": "string"
                                         },
                                         "pathType": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "enum": [
+                                                "ImplementationSpecific",
+                                                "Prefix",
+                                                "Exact"
+                                            ]
                                         }
                                     }
                                 }

--- a/scripts/pre-commit-helm-schema.sh
+++ b/scripts/pre-commit-helm-schema.sh
@@ -17,4 +17,9 @@ if ! helm plugin list | grep -qw schema-gen; then
 fi
 
 helm schema-gen "$CHART_DIR/values.yaml" > "$SCHEMA_FILE"
+
+# Restrict allowed values for ingress.pathType
+jq --indent 4 '.properties.ingress.properties.hosts.items.properties.paths.items.properties.pathType += {"enum": ["ImplementationSpecific", "Prefix", "Exact"]}' "$SCHEMA_FILE" > "${SCHEMA_FILE}.tmp"
+mv "${SCHEMA_FILE}.tmp" "$SCHEMA_FILE"
+
 diff -u "$CHART_DIR/values.schema.json" "$SCHEMA_FILE"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -36,6 +36,8 @@ helm unittest "$CHART_DIR"
 if helm plugin list | grep -qw schema-gen; then
   temp_schema=$(mktemp) || { echo "Failed to create temporary file" >&2; exit 1; }
   helm schema-gen "$CHART_DIR"/values.yaml > "$temp_schema"
+  jq --indent 4 '.properties.ingress.properties.hosts.items.properties.paths.items.properties.pathType += {"enum": ["ImplementationSpecific", "Prefix", "Exact"]}' "$temp_schema" > "${temp_schema}.tmp"
+  mv "${temp_schema}.tmp" "$temp_schema"
   diff -u "$CHART_DIR"/values.schema.json "$temp_schema"
   rm -f "$temp_schema"
 fi


### PR DESCRIPTION
## Summary
- enforce a strict set of values for `ingress.hosts[].paths[].pathType`
- update generation scripts and workflow to inject the allowed list
- regenerate `values.schema.json`

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852a56dd448832ab9706f154cfb0df8