### PR TITLE
Fix CI doc check by regenerating helm docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,8 @@ generated from `values.yaml`. Install the `helm-schema-gen` plugin as shown
 above so the check can run locally.
 Verify the chart locally with the same commands used in CI. The provided
 `scripts/run-tests.sh` helper installs missing dependencies, builds the chart
-dependencies and runs the lint and unit tests:
+dependencies, checks that the documentation is up to date and then runs the
+lint and unit tests:
 
 ```bash
 ./scripts/run-tests.sh

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -16,7 +16,7 @@ helm install my-n8n n8n/n8n --namespace my-n8n --create-namespace
 ```
 All examples install into the `my-n8n` namespace which you can change as needed.
 
-Customise the deployment by supplying your own `values.yaml` or overriding settings on the command line. See the [Pod Security](#pod-security) section to label the namespace.
+Customise the deployment by supplying your own `values.yaml` or overriding settings on the command line.
 
 ## Common configuration options
 
@@ -70,27 +70,14 @@ Automatic mounting of the ServiceAccount token is disabled via
 `serviceAccount.automount` to limit access to the Kubernetes API and reduce the
 attack surface.
 
-### Pod Security
+The chart can also manage Pod Security Admission labels on the release
+namespace. Specify the desired levels under the `podSecurity` block:
 
-Kubernetes namespaces should be labelled to enforce the
-"restricted" Pod Security profile. Label the namespace manually:
-
-```bash
-kubectl label --overwrite namespace my-n8n \
-  pod-security.kubernetes.io/enforce=restricted \
-  pod-security.kubernetes.io/audit=restricted \
-  pod-security.kubernetes.io/warn=restricted
-```
-
-The chart can also manage these labels when installed. Set the desired
-levels under the `podSecurity` block or pass them on the command line:
-
-```bash
-helm install my-n8n n8n/n8n \
-  --namespace my-n8n --create-namespace \
-  --set podSecurity.enforce=restricted \
-  --set podSecurity.audit=restricted \
-  --set podSecurity.warn=restricted
+```yaml
+podSecurity:
+  enforce: restricted
+  audit: restricted
+  warn: restricted
 ```
 
 ## Updating n8n versions

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -27,6 +27,14 @@ helm repo update >/dev/null || true
 # Build chart dependencies
 helm dependency build "$CHART_DIR" >/dev/null
 
+# Verify documentation is up to date
+if command -v helm-docs >/dev/null; then
+  helm-docs >/dev/null
+  git diff --exit-code
+else
+  echo "helm-docs not installed; skipping documentation check" >&2
+fi
+
 # Lint and unit test chart
 helm lint --strict "$CHART_DIR"
 helm unittest "$CHART_DIR"


### PR DESCRIPTION
## Summary
- run `helm-docs` to sync chart docs
- note doc check in `scripts/run-tests.sh`
- check doc generation in the helper script

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857e258bcb8832abf25faa169afc8a9