### PR TITLE
Enable automated PR merges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "automerge": true,
+  "automergeType": "pr",
+  "deleteBranchAfterMerge": true,
   "regexManagers": [
     {
       "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],

--- a/.github/workflows/check-n8n-version.yaml
+++ b/.github/workflows/check-n8n-version.yaml
@@ -37,6 +37,7 @@ jobs:
           helm-docs
       - name: Create Pull Request
         if: steps.latest.outputs.latest != steps.current.outputs.current
+        id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore: update n8n version to ${{ steps.latest.outputs.latest }}"
@@ -45,3 +46,10 @@ jobs:
           branch: "update-n8n-${{ steps.latest.outputs.latest }}"
           delete-branch: true
           labels: automated
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ The configuration in [.github/renovate.json](.github/renovate.json) monitors the
 GitHub Actions used in this repository and the Helm tooling versions referenced
 in the workflows. When a new version of the `helm-docs` plugin or a GitHub
 Action becomes available, Renovate opens a pull request with the update.
-Maintainers should review these PRs and merge them once the checks pass.
+These pull requests are automatically merged once all checks succeed.
 ---
 ## Verifying chart signatures
 


### PR DESCRIPTION
## Summary
- let `check-n8n-version` enable auto‑merge on its PRs
- configure Renovate to auto‑merge and delete branches
- document automated merges in the README

## Testing
- `pre-commit run --files README.md .github/renovate.json .github/workflows/check-n8n-version.yaml` *(fails: helm-docs and helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857e8770680832a87dd87975f295150