### PR TITLE
Add pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,35 @@
+name: Pre-commit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Add Helm repository
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+      - name: Build chart dependencies
+        run: helm dependency build n8n
+      - name: Install helm-docs
+        run: |
+          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+            | tar -xz -C /usr/local/bin helm-docs
+      - name: Install helm-schema-gen plugin
+        run: helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files


### PR DESCRIPTION
## Summary
- add GitHub Action to run pre-commit hooks on pushes to `main` and pull requests

## Testing
- `pre-commit run --all-files` *(fails: helm and helm-docs missing)*

------
https://chatgpt.com/codex/tasks/task_e_685800feb784832aa1acb39025dca361