### PR TITLE
Add workflow for checking PostgreSQL chart

### DIFF
--- a/.github/workflows/check-postgres-version.yml
+++ b/.github/workflows/check-postgres-version.yml
@@ -1,0 +1,57 @@
+name: Check PostgreSQL Chart Version
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Add Helm repository
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update
+      - name: Get latest PostgreSQL version
+        id: latest
+        run: |
+          latest=$(helm search repo bitnami/postgresql --versions | awk 'NR==2{print $2}')
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+      - name: Get chart version
+        id: current
+        run: |
+          current=$(grep -A2 'name: postgresql' n8n/Chart.yaml | grep version | awk '{print $2}')
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+      - name: Install helm-docs
+        if: steps.latest.outputs.latest != steps.current.outputs.current
+        run: |
+          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+            | tar -xz -C /usr/local/bin helm-docs
+      - name: Update files
+        if: steps.latest.outputs.latest != steps.current.outputs.current
+        run: |
+          sed -i -E "/name: postgresql/{n;s/version: .*/version: ${{ steps.latest.outputs.latest }}/;}" n8n/Chart.yaml
+          helm-docs
+      - name: Create Pull Request
+        if: steps.latest.outputs.latest != steps.current.outputs.current
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update postgresql chart version to ${{ steps.latest.outputs.latest }}"
+          title: "chore: update postgresql chart version to ${{ steps.latest.outputs.latest }}"
+          body: "Automated update of PostgreSQL chart dependency to ${{ steps.latest.outputs.latest }}."
+          branch: "update-postgresql-${{ steps.latest.outputs.latest }}"
+          delete-branch: true
+          labels: automated
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- automate checking for new Bitnami PostgreSQL Helm releases
- open a PR bumping the dependency and enable auto-merge when tests pass

## Testing
- `bash scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685806b505b0832aae1cbcb5df849b8c