### PR TITLE
Update Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,17 @@
   "automerge": true,
   "automergeType": "pr",
   "deleteBranchAfterMerge": true,
+  "packageRules": [
+    {
+      "matchManagers": ["helm"],
+      "matchPackageNames": ["postgresql"],
+      "groupName": "bitnami/postgresql"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],


### PR DESCRIPTION
## Summary
- add Renovate package rules for postgresql and GitHub actions

## Testing
- `pre-commit run --files .github/renovate.json` *(fails: helm-docs command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685807d14f8c832ab2716002f1b82d6b