### PR TITLE
Add GHCR publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,18 @@ jobs:
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install helm-push plugin
+        run: helm plugin install https://github.com/chartmuseum/helm-push.git
+
+      - name: Push chart package to OCI registry
+        if: steps.cr.outputs.changed_charts != ''
+        env:
+          OCI_REPO: ghcr.io/${{ github.repository_owner }}/charts
+        run: |
+          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          chart=$(ls .cr-release-packages/n8n-*.tgz | head -n 1)
+          helm push "$chart" "oci://$OCI_REPO"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ helm install my-n8n n8n/n8n --namespace my-n8n --create-namespace
 ```
 All examples install into the `my-n8n` namespace which you can change as needed.
 
+### Pulling from the OCI registry
+
+Chart packages are also published to the GitHub Container Registry.
+Authenticate with Helm and pull a specific version:
+
+```bash
+helm registry login ghcr.io -u <username> -p <token>
+helm pull oci://ghcr.io/<owner>/charts/n8n --version <version>
+```
+
+Replace `<version>` with the desired chart version.
+
 
 Customise the deployment by editing the values in `n8n/values.yaml` or by supplying your own values file.
 


### PR DESCRIPTION
## Summary
- push Helm charts to GHCR using helm-push
- document downloading charts from the OCI registry

## Testing
- `bash scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685808a8632c832a91904d2915e03ff3