### PR TITLE
Update lint workflow for Kubernetes matrix

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,17 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s:
+          - v1.21.14
+          - v1.22.17
+          - v1.23.17
+          - v1.24.17
+          - v1.25.16
+          - v1.26.15
+          - v1.27.16
+          - v1.28.15
     steps:
       - uses: actions/checkout@v4
       - name: Setup Helm
@@ -82,6 +93,17 @@ jobs:
   install:
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      matrix:
+        k8s:
+          - v1.21.14
+          - v1.22.17
+          - v1.23.17
+          - v1.24.17
+          - v1.25.16
+          - v1.26.15
+          - v1.27.16
+          - v1.28.15
     steps:
       - uses: actions/checkout@v4
       - name: Setup Helm
@@ -92,6 +114,7 @@ jobs:
         uses: helm/kind-action@v1.12.0
         with:
           wait: 120s
+          node_image: kindest/node:${{ matrix.k8s }}
       - name: Check cluster readiness
         run: kubectl get nodes && kubectl get pods --all-namespaces
       - name: Add Helm repository


### PR DESCRIPTION
## Summary
- test Helm charts across multiple Kubernetes versions

## Testing
- `bash scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68580a61afa8832a83f947fc816597eb