### PR TITLE
Automate CHANGELOG generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Install git-chglog
+        uses: craicoverflow/install-git-chglog@v1
+
+      - name: Generate changelog
+        run: git-chglog -o CHANGELOG.md
+
+      - name: Commit changelog
+        run: |
+          git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changelog updates"
+          else
+            git commit -m "chore: update CHANGELOG" && git push
+          fi
+
       - name: Run chart-releaser
         id: cr
         uses: helm/chart-releaser-action@v1.7.0

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ To publish a new version:
 
 1. Ensure a branch named `gh-pages` exists in the repository and configure GitHub Pages to use it. The branch can start with an empty `index.yaml` file.
 2. Update the `version` (and optionally `appVersion`) fields in `n8n/Chart.yaml`.
-3. Record the changes in `CHANGELOG.md`.
+3. Record the changes in `CHANGELOG.md` (the release workflow also updates this file automatically).
 4. Commit the change to the `main` branch.
 5. Push the commit to GitHub. The [`release.yaml`](.github/workflows/release.yaml) workflow packages the chart from the `n8n` directory and uploads it to a GitHub release.
 6. Once the workflow completes, the repository index on the `gh-pages` branch is updated at <https://anyfavors.github.io/n8n-helm>.


### PR DESCRIPTION
## Summary
- automate CHANGELOG generation in release workflow
- note automatic updates in README

## Testing
- `./scripts/run-tests.sh`
- `pre-commit run --files .github/workflows/release.yaml README.md`

------
https://chatgpt.com/codex/tasks/task_e_68580d99f2e4832a8de1fe83a0d8901e