### PR TITLE
Add caching for helm plugins

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,18 +28,33 @@ jobs:
         uses: azure/setup-helm@v4
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Cache Helm plugins and helm-docs
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.HOME }}/.local/share/helm/plugins
+            /usr/local/bin/helm-docs
+          key: ${{ runner.os }}-helm-plugins-v1
       - name: Add Helm repository
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
       - name: Build chart dependencies
         run: helm dependency build n8n
       - name: Install helm-docs
         run: |
-          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
-            | tar -xz -C /usr/local/bin helm-docs
+          if [ ! -f /usr/local/bin/helm-docs ]; then
+            curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+              | tar -xz -C /usr/local/bin helm-docs
+          fi
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+        run: |
+          if [ ! -d "$HOME/.local/share/helm/plugins/helm-unittest" ]; then
+            helm plugin install https://github.com/helm-unittest/helm-unittest
+          fi
       - name: Install helm-schema-gen plugin
-        run: helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+        run: |
+          if [ ! -d "$HOME/.local/share/helm/plugins/helm-schema-gen" ]; then
+            helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+          fi
       - name: Verify chart documentation
         run: |
           helm-docs

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,16 +19,28 @@ jobs:
         uses: azure/setup-helm@v4
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Cache Helm plugins and helm-docs
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.HOME }}/.local/share/helm/plugins
+            /usr/local/bin/helm-docs
+          key: ${{ runner.os }}-helm-plugins-v1
       - name: Add Helm repository
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
       - name: Build chart dependencies
         run: helm dependency build n8n
       - name: Install helm-docs
         run: |
-          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
-            | tar -xz -C /usr/local/bin helm-docs
+          if [ ! -f /usr/local/bin/helm-docs ]; then
+            curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+              | tar -xz -C /usr/local/bin helm-docs
+          fi
       - name: Install helm-schema-gen plugin
-        run: helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+        run: |
+          if [ ! -d "$HOME/.local/share/helm/plugins/helm-schema-gen" ]; then
+            helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+          fi
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:


### PR DESCRIPTION
## Summary
- cache Helm plugins and helm-docs in lint and pre-commit workflows
- skip Helm plugin and helm-docs installs when already present

## Testing
- `pre-commit run --files .github/workflows/lint.yaml .github/workflows/pre-commit.yml`
- `bash scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6858100fab9c832abe02a41d7fbe6ea1