### PR TITLE
Add reusable helm setup action

### DIFF
--- a/.github/actions/setup-helm-tools/action.yml
+++ b/.github/actions/setup-helm-tools/action.yml
@@ -1,0 +1,27 @@
+name: Setup Helm Tools
+runs:
+  using: composite
+  steps:
+    - name: Setup Helm
+      uses: azure/setup-helm@v4
+      env:
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+    - name: Add Bitnami repo
+      run: helm repo add bitnami https://charts.bitnami.com/bitnami
+    - name: Build chart dependencies
+      run: helm dependency build n8n
+    - name: Install helm-docs
+      run: |
+        if [ ! -f /usr/local/bin/helm-docs ]; then
+          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz | tar -xz -C /usr/local/bin helm-docs
+        fi
+    - name: Install helm-unittest plugin
+      run: |
+        if [ ! -d "$HOME/.local/share/helm/plugins/helm-unittest" ]; then
+          helm plugin install https://github.com/helm-unittest/helm-unittest
+        fi
+    - name: Install helm-schema-gen plugin
+      run: |
+        if [ ! -d "$HOME/.local/share/helm/plugins/helm-schema-gen" ]; then
+          helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+        fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,10 +28,6 @@ jobs:
           - v1.28.15
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Cache Helm plugins and helm-docs
         uses: actions/cache@v3
         with:
@@ -39,26 +35,10 @@ jobs:
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
           key: ${{ runner.os }}-helm-plugins-v1
-      - name: Add Helm repository
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
-      - name: Build chart dependencies
-        run: helm dependency build n8n
-      - name: Install helm-docs
-        run: |
-          if [ ! -f /usr/local/bin/helm-docs ]; then
-            curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
-              | tar -xz -C /usr/local/bin helm-docs
-          fi
-      - name: Install helm-unittest plugin
-        run: |
-          if [ ! -d "$HOME/.local/share/helm/plugins/helm-unittest" ]; then
-            helm plugin install https://github.com/helm-unittest/helm-unittest
-          fi
-      - name: Install helm-schema-gen plugin
-        run: |
-          if [ ! -d "$HOME/.local/share/helm/plugins/helm-schema-gen" ]; then
-            helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
-          fi
+      - name: Setup Helm tools
+        uses: ./.github/actions/setup-helm-tools
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Verify chart documentation
         run: |
           helm-docs
@@ -133,8 +113,8 @@ jobs:
           - v1.28.15
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
+      - name: Setup Helm tools
+        uses: ./.github/actions/setup-helm-tools
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Create kind cluster
@@ -144,10 +124,6 @@ jobs:
           node_image: kindest/node:${{ matrix.k8s }}
       - name: Check cluster readiness
         run: kubectl get nodes && kubectl get pods --all-namespaces
-      - name: Add Helm repository
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
-      - name: Build chart dependencies
-        run: helm dependency build ./n8n
       - name: Install chart
         run: helm install my-n8n ./n8n --wait --timeout 300s
       - name: Debug Helm installation

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,10 +19,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Cache Helm plugins and helm-docs
         uses: actions/cache@v3
         with:
@@ -30,21 +26,10 @@ jobs:
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
           key: ${{ runner.os }}-helm-plugins-v1
-      - name: Add Helm repository
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
-      - name: Build chart dependencies
-        run: helm dependency build n8n
-      - name: Install helm-docs
-        run: |
-          if [ ! -f /usr/local/bin/helm-docs ]; then
-            curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
-              | tar -xz -C /usr/local/bin helm-docs
-          fi
-      - name: Install helm-schema-gen plugin
-        run: |
-          if [ ! -d "$HOME/.local/share/helm/plugins/helm-schema-gen" ]; then
-            helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
-          fi
+      - name: Setup Helm tools
+        uses: ./.github/actions/setup-helm-tools
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:


### PR DESCRIPTION
## Summary
- create `.github/actions/setup-helm-tools` composite action
- use the new action in the pre‑commit and lint workflows

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml .github/workflows/lint.yaml .github/actions/setup-helm-tools/action.yml` *(fails: helm-docs not found)*
- `./scripts/run-tests.sh` *(fails: helm is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68581483c82c832aa8e6f0150fddf9cd