### PR TITLE
Add cache for pre-commit action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,6 +30,11 @@ jobs:
         uses: ./.github/actions/setup-helm-tools
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Cache pre-commit
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:


### PR DESCRIPTION
## Summary
- cache `~/.cache/pre-commit` in workflow
- invalidate cache when `.pre-commit-config.yaml` changes

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml` *(fails: helm-docs and helm missing)*

------
https://chatgpt.com/codex/tasks/task_e_685816281358832ab6cff9123af0ace4