### PR TITLE
Add release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE (#$NUMBER) by @$AUTHOR'
+template: |
+  ## What's Changed
+  $CHANGES
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+categories:
+  - title: 'Added'
+    labels:
+      - enhancement
+      - feature
+  - title: 'Changed'
+    labels:
+      - chore
+      - ci
+      - refactor
+  - title: 'Fixed'
+    labels:
+      - bug
+  - title: 'Documentation'
+    labels:
+      - documentation
+      - docs
+  - title: 'Dependencies'
+    labels:
+      - dependencies
+  - title: 'Other Changes'
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,11 @@ jobs:
             git commit -m "chore: update CHANGELOG" && git push
           fi
 
+      - name: Draft release notes
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run chart-releaser
         id: cr
         uses: helm/chart-releaser-action@v1.7.0


### PR DESCRIPTION
## Summary
- generate release notes with release-drafter
- run release-drafter in the release workflow

## Testing
- `bash -x ./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68581a5c68f8832a9043f3b3a141734b