### PR TITLE
Add Helm template comment workflow

### DIFF
--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -1,0 +1,45 @@
+name: Render Helm Template
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Helm tools
+        uses: ./.github/actions/setup-helm-tools
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Render chart
+        id: render
+        run: |
+          helm template n8n > template.txt
+          size=$(wc -c < template.txt)
+          echo "size=$size" >> "$GITHUB_OUTPUT"
+      - name: Upload template artifact
+        if: steps.render.outputs.size > 65000
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-template
+          path: template.txt
+      - name: Comment with template
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body = fs.readFileSync('template.txt', 'utf8');
+            const limit = 65000;
+            if (body.length > limit) {
+              body = body.slice(0, limit) + '\n\nOutput truncated. Download artifact for full template.';
+            }
+            github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body,
+            });


### PR DESCRIPTION
## Summary
- post `helm template n8n` output on PRs

## Testing
- `pre-commit run --files .github/workflows/template-comment.yml` *(fails: InvalidManifestError: /root/.cache/pre-commit/repoybhe_6tw/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68581c063d70832a86b73aaeed719fc9