### PR TITLE
Remove --all-files in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -37,5 +37,3 @@ jobs:
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --all-files


### PR DESCRIPTION
## Summary
- remove the `--all-files` argument from the pre-commit workflow so hooks run only on files changed in the PR

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml` *(fails: InvalidManifestError)*


------
https://chatgpt.com/codex/tasks/task_e_68582653df2c832ab10bc130de196c1d