### PR TITLE
Add Helm tooling container and cache Helm version

### DIFF
--- a/.github/docker/helm-tools.Dockerfile
+++ b/.github/docker/helm-tools.Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+ARG HELM_VERSION=v3.18.3
+ARG HELM_DOCS_VERSION=v1.14.2
+
+RUN apt-get update && \
+    apt-get install -y curl git ca-certificates jq && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Helm
+RUN curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xz && \
+    mv linux-amd64/helm /usr/local/bin/helm && \
+    rm -rf linux-amd64
+
+# Install helm-docs
+RUN curl -fsSL https://github.com/norwoodj/helm-docs/releases/download/${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION#v}_Linux_x86_64.tar.gz | \
+    tar -xz -C /usr/local/bin helm-docs
+
+# Install Helm plugins
+RUN helm plugin install https://github.com/helm-unittest/helm-unittest && \
+    helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+
+# Add Bitnami repo for dependencies
+RUN helm repo add bitnami https://charts.bitnami.com/bitnami && helm repo update
+
+WORKDIR /charts
+
+ENTRYPOINT ["bash"]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/helm-tools:latest
     strategy:
       matrix:
         k8s:
@@ -28,13 +30,15 @@ jobs:
           - v1.28.15
     steps:
       - uses: actions/checkout@v4
+      - name: Set Helm version
+        run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Cache Helm plugins and helm-docs
         uses: actions/cache@v3
         with:
           path: |
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
-          key: ${{ runner.os }}-helm-plugins-v1
+          key: ${{ runner.os }}-helm-plugins-${{ env.HELM_VERSION }}-v1
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
         env:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,12 @@ concurrency:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/helm-tools:latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set Helm version
+        run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -25,7 +29,7 @@ jobs:
           path: |
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
-          key: ${{ runner.os }}-helm-plugins-v1
+          key: ${{ runner.os }}-helm-plugins-${{ env.HELM_VERSION }}-v1
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
         env:


### PR DESCRIPTION
## Summary
- add a Dockerfile providing helm tooling
- run lint and pre-commit in the tooling container
- cache helm plugins keyed by the helm version

## Testing
- `bash -x ./scripts/run-tests.sh`
- `pre-commit run --files .github/workflows/pre-commit.yml .github/workflows/lint.yaml .github/docker/helm-tools.Dockerfile` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_68582bd4e858832abc8bf556b847b935