### PR TITLE
Fix lint workflow scanning

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -90,17 +90,14 @@ jobs:
           exit-code: 1
           severity: HIGH
           args: --ignorefile .trivyignore
-      - name: Install Trivy
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wget
-          wget -qO- https://github.com/aquasecurity/trivy/releases/download/v0.63.0/trivy_0.63.0_Linux-64bit.deb > trivy.deb
-          sudo dpkg -i trivy.deb
-          rm trivy.deb
       - name: Scan container image for vulnerabilities
-        run: |
-          trivy image n8nio/n8n:${{ steps.chart.outputs.version }} \
-            --severity HIGH,CRITICAL --exit-code 1 --ignorefile .trivyignore
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          scan-type: image
+          image-ref: n8nio/n8n:${{ steps.chart.outputs.version }}
+          exit-code: 1
+          severity: HIGH,CRITICAL
+          args: --ignorefile .trivyignore
   install:
     runs-on: ubuntu-latest
     needs: lint


### PR DESCRIPTION
## Summary
- use Trivy GitHub action to scan the container image
- remove local apt-based Trivy install step

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_68582ddbf5ec832a97dacbd1589397e2