### PR TITLE
Add path filter for Helm docs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,7 +43,15 @@ jobs:
         uses: ./.github/actions/setup-helm-tools
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Check for chart changes
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            n8n:
+              - 'n8n/**'
       - name: Verify chart documentation
+        if: steps.filter.outputs.n8n == 'true'
         run: |
           helm-docs
           if ! git diff --quiet; then


### PR DESCRIPTION
## Summary
- only update Helm docs when files under `n8n/` change

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_68582ecfd86c832a8b51088e0306137d