### PR TITLE
Fix Helm cache keys

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,7 +38,7 @@ jobs:
           path: |
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
-          key: ${{ runner.os }}-helm-plugins-${{ env.HELM_VERSION }}-v1
+          key: helm-plugins-${{ env.HELM_VERSION }}
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
         env:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,7 @@ jobs:
           path: |
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
-          key: ${{ runner.os }}-helm-plugins-${{ env.HELM_VERSION }}-v1
+          key: helm-plugins-${{ env.HELM_VERSION }}
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
         env:


### PR DESCRIPTION
## Summary
- use `helm-plugins-${{ env.HELM_VERSION }}` for helm cache keys

## Testing
- `scripts/run-tests.sh`
- `pre-commit` *(fails: /root/.cache/pre-commit/repop1yt4b3s/.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68582fb75508832a9d458a6c94046368