### PR TITLE
Add caching for helm-unittest plugin

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,6 +32,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+      - name: Cache helm-unittest plugin
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
+          key: helm-unittest-${{ env.HELM_VERSION }}
       - name: Cache Helm plugins and helm-docs
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+      - name: Cache helm-unittest plugin
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
+          key: helm-unittest-${{ env.HELM_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -12,6 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set Helm version
+        run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+      - name: Cache helm-unittest plugin
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
+          key: helm-unittest-${{ env.HELM_VERSION }}
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
         env:


### PR DESCRIPTION
## Summary
- cache the helm-unittest plugin in GitHub workflows

## Testing
- `bash scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6858359eca20832a83dc84aae700645c