### PR TITLE
Insert helm-docs cache in version check workflows

### DIFF
--- a/.github/workflows/check-n8n-version.yaml
+++ b/.github/workflows/check-n8n-version.yaml
@@ -10,6 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set Helm version
+        run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+      - name: Cache Helm plugins and helm-docs
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.HOME }}/.local/share/helm/plugins
+            /usr/local/bin/helm-docs
+          key: helm-plugins-${{ env.HELM_VERSION }}
       - name: Get latest n8n version
         id: latest
         run: |
@@ -27,8 +36,10 @@ jobs:
       - name: Install helm-docs
         if: steps.latest.outputs.latest != steps.current.outputs.current
         run: |
-          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
-            | tar -xz -C /usr/local/bin helm-docs
+          if [ ! -f /usr/local/bin/helm-docs ]; then
+            curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+              | tar -xz -C /usr/local/bin helm-docs
+          fi
       - name: Update files
         if: steps.latest.outputs.latest != steps.current.outputs.current
         run: |

--- a/.github/workflows/check-postgres-version.yml
+++ b/.github/workflows/check-postgres-version.yml
@@ -10,6 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set Helm version
+        run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+      - name: Cache Helm plugins and helm-docs
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.HOME }}/.local/share/helm/plugins
+            /usr/local/bin/helm-docs
+          key: helm-plugins-${{ env.HELM_VERSION }}
       - name: Setup Helm
         uses: azure/setup-helm@v4
         env:
@@ -31,8 +40,10 @@ jobs:
       - name: Install helm-docs
         if: steps.latest.outputs.latest != steps.current.outputs.current
         run: |
-          curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
-            | tar -xz -C /usr/local/bin helm-docs
+          if [ ! -f /usr/local/bin/helm-docs ]; then
+            curl -sSL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz \
+              | tar -xz -C /usr/local/bin helm-docs
+          fi
       - name: Update files
         if: steps.latest.outputs.latest != steps.current.outputs.current
         run: |


### PR DESCRIPTION
## Summary
- cache Helm plugins and helm-docs before installing helm-docs in check workflows
- avoid downloading helm-docs when cache provides it

## Testing
- `./scripts/run-tests.sh` *(fails: helm is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858372f1778832a9e51816449586f90