### PR TITLE
Integrate vulnerability scans into lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,8 +15,6 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/helm-tools:latest
     strategy:
       matrix:
         k8s:
@@ -84,12 +82,6 @@ jobs:
               git add n8n/values.schema.json
               git commit -m "ci: Update Helm values schema"
             fi
-
-  scan:
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - uses: actions/checkout@v4
       - name: Get chart version
         id: chart
         run: |
@@ -111,6 +103,7 @@ jobs:
           exit-code: 1
           severity: HIGH,CRITICAL
           args: --ignorefile .trivyignore
+
   install:
     runs-on: ubuntu-latest
     needs: lint


### PR DESCRIPTION
## Summary
- run Trivy scans as steps of the lint workflow
- drop the dedicated scan job
- remove the container requirement for lint job

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685838840594832a821bc01f77937a76