### PR TITLE
Use Helm tools container in workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    container: ghcr.io/anyfavors/helm-tools:latest
     strategy:
       matrix:
         k8s:
@@ -42,10 +43,6 @@ jobs:
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
           key: helm-plugins-${{ env.HELM_VERSION }}
-      - name: Setup Helm tools
-        uses: ./.github/actions/setup-helm-tools
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Check for chart changes
         id: filter
         uses: dorny/paths-filter@v2
@@ -106,6 +103,7 @@ jobs:
 
   install:
     runs-on: ubuntu-latest
+    container: ghcr.io/anyfavors/helm-tools:latest
     needs: lint
     strategy:
       matrix:
@@ -115,10 +113,6 @@ jobs:
           - v1.28.15
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Helm tools
-        uses: ./.github/actions/setup-helm-tools
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Create kind cluster
         uses: helm/kind-action@v1.12.0
         with:

--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   render:
     runs-on: ubuntu-latest
+    container: ghcr.io/anyfavors/helm-tools:latest
     steps:
       - uses: actions/checkout@v4
       - name: Set Helm version
@@ -19,10 +20,6 @@ jobs:
         with:
           path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
           key: helm-unittest-${{ env.HELM_VERSION }}
-      - name: Setup Helm tools
-        uses: ./.github/actions/setup-helm-tools
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Render chart
         id: render
         run: |

--- a/README.md
+++ b/README.md
@@ -539,6 +539,15 @@ Install the tool and set up the Git hooks:
 pip install pre-commit
 pre-commit install
 ```
+If you prefer not to install the tooling locally, a Docker image with the
+required Helm utilities is available at
+`ghcr.io/anyfavors/helm-tools`.
+For example, run the test script inside the container with:
+
+```bash
+docker run --rm -it -v $(pwd):/charts ghcr.io/anyfavors/helm-tools ./scripts/run-tests.sh
+```
+
 Install [Helm](https://helm.sh) first:
 
 ```bash


### PR DESCRIPTION
## Summary
- use `ghcr.io/anyfavors/helm-tools` container in lint and install jobs
- use the same container in the template-comment workflow
- document the pre-built Helm tools image

## Testing
- `docker build -t ghcr.io/anyfavors/helm-tools:latest -f .github/docker/helm-tools.Dockerfile .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685842f25540832a8e2a39fc2c62eec2