### PR TITLE
Add paths filter job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      n8n: ${{ steps.filter.outputs.n8n }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            n8n:
+              - 'n8n/**'
   lint:
     runs-on: ubuntu-latest
+    needs: filter
+    if: needs.filter.outputs.n8n == "true"
     container: ghcr.io/anyfavors/helm-tools:latest
     strategy:
       matrix:
@@ -43,15 +57,8 @@ jobs:
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
           key: helm-plugins-${{ env.HELM_VERSION }}
-      - name: Check for chart changes
-        id: filter
-        uses: dorny/paths-filter@v2
-        with:
-          filters: |
-            n8n:
-              - 'n8n/**'
       - name: Verify chart documentation
-        if: steps.filter.outputs.n8n == 'true'
+        if: needs.filter.outputs.n8n == 'true'
         run: |
           helm-docs
           if ! git diff --quiet; then
@@ -104,7 +111,8 @@ jobs:
   install:
     runs-on: ubuntu-latest
     container: ghcr.io/anyfavors/helm-tools:latest
-    needs: lint
+    needs: [filter, lint]
+    if: needs.filter.outputs.n8n == "true"
     strategy:
       matrix:
         k8s:


### PR DESCRIPTION
## Summary
- add filter job to skip lint/install when no chart changes
- gate lint and install jobs on filter output

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685846925cac832a9b7d34a1e420d1f3