### PR TITLE
Add docker image caching for kind action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -124,6 +124,15 @@ jobs:
           - v1.28.15
     steps:
       - uses: actions/checkout@v4
+      - name: Cache kind node image
+        id: kind-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.HOME }}/kind-node-${{ matrix.k8s }}.tar
+          key: kind-node-${{ matrix.k8s }}
+      - name: Load node image from cache
+        if: steps.kind-cache.outputs.cache-hit == 'true'
+        run: docker load -i $HOME/kind-node-${{ matrix.k8s }}.tar
       - name: Create kind cluster
         uses: helm/kind-action@v1.12.0
         with:
@@ -144,3 +153,6 @@ jobs:
         run: kubectl get pods -n default
       - name: Delete release
         run: helm uninstall my-n8n
+      - name: Save node image to cache
+        run: |
+          docker save kindest/node:${{ matrix.k8s }} -o $HOME/kind-node-${{ matrix.k8s }}.tar


### PR DESCRIPTION
## Summary
- cache kind node images in the install workflow
- load cached image before starting kind
- save the downloaded image for reuse

## Testing
- `scripts/run-tests.sh`
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError - .pre-commit-hooks.yaml not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584b9419bc832aae8ef36a281dc86b