### PR TITLE
Add caching for chart dependencies

### DIFF
--- a/.github/actions/setup-helm-tools/action.yml
+++ b/.github/actions/setup-helm-tools/action.yml
@@ -12,7 +12,14 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
     - name: Add Bitnami repo
       run: helm repo add bitnami https://charts.bitnami.com/bitnami
+    - name: Cache chart dependencies
+      id: charts-cache
+      uses: actions/cache@v3
+      with:
+        path: n8n/charts
+        key: charts-${{ hashFiles('n8n/Chart.lock', 'n8n/Chart.yaml') }}
     - name: Build chart dependencies
+      if: steps.charts-cache.outputs.cache-hit != 'true'
       run: helm dependency build n8n
     - name: Install helm-docs
       run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -62,7 +62,14 @@ jobs:
             git add .
             git commit -m "ci: Update Helm chart documentation"
           fi
+      - name: Cache chart dependencies
+        id: charts-cache
+        uses: actions/cache@v3
+        with:
+          path: n8n/charts
+          key: charts-${{ hashFiles('n8n/Chart.lock', 'n8n/Chart.yaml') }}
       - name: Build chart dependencies
+        if: steps.charts-cache.outputs.cache-hit != 'true'
         run: helm dependency build n8n
       - name: Helm lint
         run: helm lint n8n


### PR DESCRIPTION
## Summary
- cache chart dependencies in the helm setup composite action
- reuse the same cache in the lint workflow

## Testing
- `pre-commit run --files .github/actions/setup-helm-tools/action.yml .github/workflows/lint.yaml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_68584fbcf42c832a9b70d1ceb92fc356