### PR TITLE
Restrict template workflow to chart changes

### DIFF
--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -2,6 +2,8 @@ name: Render Helm Template
 
 on:
   pull_request:
+    paths:
+      - 'n8n/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- run the template comment workflow only when `n8n/` files change

## Testing
- `./scripts/run-tests.sh` *(fails: helm is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685851fbbf14832a96f664a9286c0325