### PR TITLE
Update helm-tools image for pre-commit support

### DIFF
--- a/.github/docker/helm-tools.Dockerfile
+++ b/.github/docker/helm-tools.Dockerfile
@@ -4,8 +4,11 @@ ARG HELM_VERSION=v3.18.3
 ARG HELM_DOCS_VERSION=v1.14.2
 
 RUN apt-get update && \
-    apt-get install -y curl git ca-certificates jq && \
+    apt-get install -y curl git ca-certificates jq python3 python3-pip && \
     rm -rf /var/lib/apt/lists/*
+
+# Install pre-commit for linting
+RUN pip3 install --no-cache-dir pre-commit
 
 # Install Helm
 RUN curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xz && \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: filter
     if: needs.filter.outputs.n8n == "true"
-    container: ghcr.io/anyfavors/helm-tools:latest
+    container: ghcr.io/anyfavors/helm-tools:v1
     strategy:
       matrix:
         k8s:
@@ -91,7 +91,7 @@ jobs:
 
   scan:
     runs-on: ubuntu-latest
-    container: ghcr.io/anyfavors/helm-tools:latest
+    container: ghcr.io/anyfavors/helm-tools:v1
     needs: [filter, lint]
     if: needs.filter.outputs.n8n == "true"
     steps:
@@ -120,7 +120,7 @@ jobs:
 
   install:
     runs-on: ubuntu-latest
-    container: ghcr.io/anyfavors/helm-tools:latest
+    container: ghcr.io/anyfavors/helm-tools:v1
     needs: [filter, lint]
     if: needs.filter.outputs.n8n == "true"
     strategy:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/helm-tools:latest
+      image: ghcr.io/${{ github.repository_owner }}/helm-tools:v1
     steps:
       - uses: actions/checkout@v4
       - name: Set Helm version
@@ -24,10 +24,6 @@ jobs:
         with:
           path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
           key: helm-unittest-${{ env.HELM_VERSION }}
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
       - name: Cache Helm plugins and helm-docs
         uses: actions/cache@v3
         with:

--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   render:
     runs-on: ubuntu-latest
-    container: ghcr.io/anyfavors/helm-tools:latest
+    container: ghcr.io/anyfavors/helm-tools:v1
     steps:
       - uses: actions/checkout@v4
       - name: Set Helm version


### PR DESCRIPTION
## Summary
- add python3 and pre-commit to helm-tools Dockerfile
- use new v1 tag for helm-tools image in workflows
- drop setup-python step

## Testing
- `pre-commit run --files .github/docker/helm-tools.Dockerfile .github/workflows/lint.yaml .github/workflows/pre-commit.yml .github/workflows/template-comment.yml` *(fails: InvalidManifestError)*
- `docker build -t ghcr.io/anyfavors/helm-tools:v1 -f .github/docker/helm-tools.Dockerfile .` *(fails: command not found)*
- `docker push ghcr.io/anyfavors/helm-tools:v1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685853cb3970832aaa6351b3e9589700