### PR TITLE
Add cache restore-keys

### DIFF
--- a/.github/actions/setup-helm-tools/action.yml
+++ b/.github/actions/setup-helm-tools/action.yml
@@ -8,6 +8,8 @@ runs:
       with:
         path: n8n/charts
         key: charts-${{ hashFiles('n8n/Chart.lock', 'n8n/Chart.yaml') }}
+        restore-keys: |
+          charts-
     - name: Build chart dependencies
       if: steps.charts-cache.outputs.cache-hit != 'true'
       run: helm dependency build n8n

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -54,6 +54,8 @@ jobs:
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
           key: helm-plugins-${{ env.HELM_VERSION }}
+          restore-keys: |
+            helm-plugins-
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
         env:
@@ -109,6 +111,8 @@ jobs:
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
           key: helm-plugins-${{ env.HELM_VERSION }}
+          restore-keys: |
+            helm-plugins-
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
         env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,6 +46,8 @@ jobs:
         with:
           path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
           key: helm-unittest-${{ env.HELM_VERSION }}
+          restore-keys: |
+            helm-unittest-
       - name: Cache Helm plugins and helm-docs
         uses: actions/cache@v3
         with:
@@ -53,6 +55,8 @@ jobs:
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
           key: helm-plugins-${{ env.HELM_VERSION }}
+          restore-keys: |
+            helm-plugins-
       - name: Verify chart documentation
         if: needs.filter.outputs.n8n == 'true'
         run: |
@@ -69,6 +73,8 @@ jobs:
         with:
           path: n8n/charts
           key: charts-${{ hashFiles('n8n/Chart.lock', 'n8n/Chart.yaml') }}
+          restore-keys: |
+            charts-
       - name: Build chart dependencies
         if: steps.charts-cache.outputs.cache-hit != 'true'
         run: helm dependency build n8n
@@ -140,6 +146,8 @@ jobs:
         with:
           path: ${{ env.HOME }}/kind-node-${{ matrix.k8s }}.tar
           key: kind-node-${{ matrix.k8s }}
+          restore-keys: |
+            kind-node-
       - name: Load node image from cache
         if: steps.kind-cache.outputs.cache-hit == 'true'
         run: docker load -i $HOME/kind-node-${{ matrix.k8s }}.tar

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
           key: helm-unittest-${{ env.HELM_VERSION }}
+          restore-keys: |
+            helm-unittest-
       - name: Cache Helm plugins and helm-docs
         uses: actions/cache@v3
         with:
@@ -32,11 +34,15 @@ jobs:
             ${{ env.HOME }}/.local/share/helm/plugins
             /usr/local/bin/helm-docs
           key: helm-plugins-${{ env.HELM_VERSION }}
+          restore-keys: |
+            helm-plugins-
       - name: Cache pre-commit
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:

--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
           key: helm-unittest-${{ env.HELM_VERSION }}
+          restore-keys: |
+            helm-unittest-
       - name: Render chart
         id: render
         run: |


### PR DESCRIPTION
## Summary
- cache helm-unittest plugin and chart dependencies with restore-keys
- add restore-keys to helm plugin caches
- cache kind node image with restore-keys
- update check-updates workflow caching

## Testing
- `bash scripts/run-tests.sh` *(fails: helm is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685856c91d68832a9b23f65f06844cb8