### PR TITLE
Remove repo update in tests

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -28,7 +28,6 @@ fi
 
 # Add bitnami repo for postgresql dependency
 helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null 2>&1 || true
-helm repo update >/dev/null || true
 
 # Build chart dependencies
 helm dependency build "$CHART_DIR" >/dev/null


### PR DESCRIPTION
## Summary
- avoid network calls during tests by removing `helm repo update` call
- Docker image already updates Bitnami repo during build

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68585bb42490832abc4285fd4630643a