### PR TITLE
Add release tools container

### DIFF
--- a/.github/docker/release-tools.Dockerfile
+++ b/.github/docker/release-tools.Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:22.04
+
+ARG HELM_VERSION=v3.18.3
+ARG GIT_CHGLOG_VERSION=v0.15.4
+ARG CHART_RELEASER_VERSION=v1.7.0
+ARG COSIGN_VERSION=v2.5.1
+
+RUN apt-get update && \
+    apt-get install -y curl git ca-certificates jq && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Helm
+RUN curl -fsSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xz && \
+    mv linux-amd64/helm /usr/local/bin/helm && \
+    rm -rf linux-amd64
+
+# Install git-chglog
+RUN curl -fsSL https://github.com/git-chglog/git-chglog/releases/download/${GIT_CHGLOG_VERSION}/git-chglog_${GIT_CHGLOG_VERSION#v}_linux_amd64.tar.gz | \
+    tar -xz -C /usr/local/bin git-chglog
+
+# Install chart-releaser
+RUN curl -fsSL https://github.com/helm/chart-releaser/releases/download/${CHART_RELEASER_VERSION}/chart-releaser_${CHART_RELEASER_VERSION#v}_linux_amd64.tar.gz | \
+    tar -xz -C /usr/local/bin cr
+
+# Install Helm plugins
+RUN helm plugin install https://github.com/chartmuseum/helm-push.git
+
+# Install cosign
+RUN curl -fsSL https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64 -o /usr/local/bin/cosign && \
+    chmod +x /usr/local/bin/cosign
+
+WORKDIR /charts
+
+ENTRYPOINT ["bash"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Use tagged release-tools image
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/release-tools:v1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,13 +30,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Install git-chglog
-        uses: craicoverflow/install-git-chglog@v1
+      # Helm and git-chglog are pre-installed in the container
 
       - name: Generate changelog
         run: git-chglog -o CHANGELOG.md
@@ -60,8 +57,7 @@ jobs:
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install helm-push plugin
-        run: helm plugin install https://github.com/chartmuseum/helm-push.git
+      # helm-push plugin is available in the container
 
       - name: Push chart package to OCI registry
         if: steps.cr.outputs.changed_charts != ''
@@ -72,8 +68,7 @@ jobs:
           chart=$(ls .cr-release-packages/n8n-*.tgz | head -n 1)
           helm push "$chart" "oci://$OCI_REPO"
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+      # cosign is available in the container
 
       - name: Sign chart packages and upload signatures
         if: steps.cr.outputs.changed_charts != ''


### PR DESCRIPTION
## Summary
- add a release-tools Dockerfile
- use the release-tools image in `release.yaml`
- skip installing tools in the workflow

## Testing
- `pre-commit run --files .github/workflows/release.yaml .github/docker/release-tools.Dockerfile` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_68585d5fbe4c832aa06e67fbcb706ad6