### PR TITLE
Fix lint path filter for docs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,7 @@ jobs:
           filters: |
             n8n:
               - 'n8n/**'
+              - '!n8n/README.md*'
   lint:
     runs-on: ubuntu-latest
     needs: filter


### PR DESCRIPTION
## Summary
- avoid running the lint workflow for documentation-only changes

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685aba01e444832aa933991dd3165562