### PR TITLE
Remove custom pre-commit cache

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -36,14 +36,8 @@ jobs:
           key: helm-plugins-${{ env.HELM_VERSION }}
           restore-keys: |
             helm-plugins-
-      - name: Cache pre-commit
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: --files $(if [ -n "${{ github.event.pull_request.base.sha }}" ]; then git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }}; else git ls-files; fi)
+          cache: true


### PR DESCRIPTION
## Summary
- use `pre-commit/action` cache feature instead of a custom `actions/cache` step

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685abbd36804832a99d5419f6b907464