### PR TITLE
Remove caching steps from workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,22 +43,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
-      - name: Cache helm-unittest plugin
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
-          key: helm-unittest-${{ env.HELM_VERSION }}
-          restore-keys: |
-            helm-unittest-
-      - name: Cache Helm plugins and helm-docs
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.HOME }}/.local/share/helm/plugins
-            /usr/local/bin/helm-docs
-          key: helm-plugins-${{ env.HELM_VERSION }}
-          restore-keys: |
-            helm-plugins-
       - name: Verify chart documentation
         if: needs.filter.outputs.n8n == 'true'
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,22 +20,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
-      - name: Cache helm-unittest plugin
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.HOME }}/.local/share/helm/plugins/helm-unittest
-          key: helm-unittest-${{ env.HELM_VERSION }}
-          restore-keys: |
-            helm-unittest-
-      - name: Cache Helm plugins and helm-docs
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.HOME }}/.local/share/helm/plugins
-            /usr/local/bin/helm-docs
-          key: helm-plugins-${{ env.HELM_VERSION }}
-          restore-keys: |
-            helm-plugins-
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:


### PR DESCRIPTION
## Summary
- drop plugin cache from pre-commit workflow
- drop plugin cache from lint workflow
- helm-tools image already installs needed plugins at build time

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685aca09fd1c832abd283c518fb20ded