### PR TITLE
Replace manual dependency steps with setup-helm-tools

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -53,17 +53,8 @@ jobs:
             git add .
             git commit -m "ci: Update Helm chart documentation"
           fi
-      - name: Cache chart dependencies
-        id: charts-cache
-        uses: actions/cache@v3
-        with:
-          path: n8n/charts
-          key: charts-${{ hashFiles('n8n/Chart.lock', 'n8n/Chart.yaml') }}
-          restore-keys: |
-            charts-
-      - name: Build chart dependencies
-        if: steps.charts-cache.outputs.cache-hit != 'true'
-        run: helm dependency build n8n
+      - name: Setup Helm tools
+        uses: ./.github/actions/setup-helm-tools
       - name: Helm lint
         run: helm lint n8n
       - name: Helm lint with values

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+      - name: Setup Helm tools
+        uses: ./.github/actions/setup-helm-tools
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:


### PR DESCRIPTION
## Summary
- add `setup-helm-tools` step to `pre-commit` job
- replace cache and dependency build steps in `lint` job with `setup-helm-tools`

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml .github/workflows/lint.yaml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685acca2ccd4832abcec8ad154db3690