### PR TITLE
Fix Helm lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -56,8 +56,6 @@ jobs:
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
       - name: Helm lint
-        run: helm lint n8n
-      - name: Helm lint with values
         run: helm lint n8n --values n8n/values.yaml
       - name: Helm unit tests
         run: helm unittest n8n


### PR DESCRIPTION
## Summary
- combine Helm lint steps in workflow

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError)*
- `bash scripts/run-tests.sh` *(fails: helm is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685acf5d40a8832a83744df0e579bbda