### PR TITLE
Update lint workflow path filter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       n8n: ${{ steps.filter.outputs.n8n }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v4
       - id: filter
@@ -26,6 +27,9 @@ jobs:
             n8n:
               - 'n8n/**'
               - '!n8n/README.md*'
+            docs:
+              - 'n8n/templates/**'
+              - 'n8n/values.yaml'
   lint:
     runs-on: ubuntu-latest
     needs: filter
@@ -44,7 +48,7 @@ jobs:
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Verify chart documentation
-        if: needs.filter.outputs.n8n == 'true'
+        if: needs.filter.outputs.docs == 'true'
         run: |
           helm-docs
           if ! git diff --quiet; then


### PR DESCRIPTION
## Summary
- detect template or values changes with the paths filter
- run helm-docs only when templates or values changed

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError)*
- `bash scripts/run-tests.sh` *(fails: plugin repo was modified)*

------
https://chatgpt.com/codex/tasks/task_e_685ad5469af0832a85e9051814361af1