### PR TITLE
Reduce K8s matrix in lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -117,8 +117,6 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.26.15
-          - v1.27.16
           - v1.28.15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- test the Helm chart installation only against the latest Kubernetes version

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError: `.pre-commit-hooks.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_685adca9d93c832a9e2d55832d2c5d22