### PR TITLE
Fix scan job dependencies

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     # Use tagged helm-tools image
     container: ghcr.io/anyfavors/helm-tools:v1
-    needs: [filter, lint]
+    needs: filter
     if: needs.filter.outputs.n8n == "true"
     env:
       TRIVY_CACHE_DIR: ${{ env.HOME }}/.cache/trivy


### PR DESCRIPTION
## Summary
- start vulnerability scans right after the filter job

## Testing
- `pre-commit run --files .github/workflows/lint.yaml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685add8b6b00832abdfd650dc3fa084c