### PR TITLE
Fix actions cache

### DIFF
--- a/.github/actions/setup-helm-tools/action.yml
+++ b/.github/actions/setup-helm-tools/action.yml
@@ -2,6 +2,16 @@ name: Setup Helm Tools
 runs:
   using: composite
   steps:
+    - name: Cache Helm plugins and helm-docs
+      id: plugins-cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.HOME }}/.local/share/helm/plugins
+          /usr/local/bin/helm-docs
+        key: helm-plugins-${{ env.HELM_VERSION }}
+        restore-keys: |
+          helm-plugins-
     - name: Cache chart dependencies
       id: charts-cache
       uses: actions/cache@v3


### PR DESCRIPTION
## Summary
- cache helm plugins and helm-docs in composite action

## Testing
- `./scripts/run-tests.sh` *(fails: helm is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685aded93354832abbb76e31601b1197