### PR TITLE
Fix pre-commit docs filter

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,6 +23,8 @@ jobs:
           filters: |
             n8n:
               - 'n8n/**'
+              - '!n8n/README.md'
+              - '!n8n/docs/**'
 
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- adjust the pre-commit workflow filter to ignore generated docs

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685ae024be88832a8a5d8c78bd65989f