### PR TITLE
Fix pre-commit checkout depth

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,6 +17,8 @@ jobs:
       n8n: ${{ steps.filter.outputs.n8n }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - id: filter
         uses: dorny/paths-filter@v2
         with:
@@ -35,6 +37,8 @@ jobs:
       image: ghcr.io/${{ github.repository_owner }}/helm-tools:v1
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Setup Helm tools


### PR DESCRIPTION
## Summary
- avoid extra fetches by checking out full repo history in the pre-commit workflow

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml` *(fails: InvalidManifestError)*
- `./scripts/run-tests.sh` *(fails: helm is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ae131699c832ab671bd8b30b7c493