### PR TITLE
Add pre-commit cache

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -43,6 +43,13 @@ jobs:
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Setup Helm tools
         uses: ./.github/actions/setup-helm-tools
+      - name: Cache pre-commit env
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.HOME }}/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:


### PR DESCRIPTION
## Summary
- persist pre-commit environment between workflow runs

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685ae3cf06b4832a81bf193a755996c8