### PR TITLE
Bundle kind node images in helm-tools

### DIFF
--- a/.github/docker/helm-tools.Dockerfile
+++ b/.github/docker/helm-tools.Dockerfile
@@ -2,9 +2,10 @@ FROM ubuntu:22.04
 
 ARG HELM_VERSION=v3.18.3
 ARG HELM_DOCS_VERSION=v1.14.2
+ARG KIND_NODE_IMAGES="v1.26.15 v1.27.16 v1.28.15"
 
 RUN apt-get update && \
-    apt-get install -y curl git ca-certificates jq python3 python3-pip && \
+    apt-get install -y curl git ca-certificates jq python3 python3-pip skopeo && \
     rm -rf /var/lib/apt/lists/*
 
 # Install pre-commit for linting
@@ -25,6 +26,12 @@ RUN helm plugin install https://github.com/helm-unittest/helm-unittest && \
 
 # Add Bitnami repo for dependencies
 RUN helm repo add bitnami https://charts.bitnami.com/bitnami && helm repo update
+
+# Pre-download common kind node images
+RUN mkdir -p /kind-images && \
+    for version in $KIND_NODE_IMAGES; do \
+        skopeo copy docker://kindest/node:${version} docker-archive:/kind-images/kind-node-${version}.tar:kindest/node:${version}; \
+    done
 
 WORKDIR /charts
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
     needs: filter
     if: needs.filter.outputs.n8n == "true"
     # Use tagged helm-tools image
-    container: ghcr.io/anyfavors/helm-tools:v1
+    container: ghcr.io/anyfavors/helm-tools:v2
     steps:
       - uses: actions/checkout@v4
       - name: Set Helm version
@@ -71,7 +71,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     # Use tagged helm-tools image
-    container: ghcr.io/anyfavors/helm-tools:v1
+    container: ghcr.io/anyfavors/helm-tools:v2
     needs: filter
     if: needs.filter.outputs.n8n == "true"
     env:
@@ -111,7 +111,7 @@ jobs:
   install:
     runs-on: ubuntu-latest
     # Use tagged helm-tools image
-    container: ghcr.io/anyfavors/helm-tools:v1
+    container: ghcr.io/anyfavors/helm-tools:v2
     needs: [filter, lint]
     if: needs.filter.outputs.n8n == "true"
     strategy:
@@ -120,34 +120,8 @@ jobs:
           - v1.28.15
     steps:
       - uses: actions/checkout@v4
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Cache kind node image
-        id: kind-cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.HOME }}/kind-node-${{ matrix.k8s }}.tar
-          key: kind-node-${{ matrix.k8s }}
-          restore-keys: |
-            kind-node-
-      - name: Download node image artifact
-        if: steps.kind-cache.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: kind-node-${{ matrix.k8s }}
-          path: ${{ env.HOME }}
-        continue-on-error: true
-      - name: Load node image from artifact
-        if: steps.kind-cache.outputs.cache-hit != 'true'
-        run: |
-          if [ -f "$HOME/kind-node-${{ matrix.k8s }}.tar" ]; then
-            docker load -i "$HOME/kind-node-${{ matrix.k8s }}.tar"
-          else
-            docker pull ghcr.io/${{ github.repository_owner }}/kind-node:${{ matrix.k8s }}
-          fi
-      - name: Load node image from cache
-        if: steps.kind-cache.outputs.cache-hit == 'true'
-        run: docker load -i $HOME/kind-node-${{ matrix.k8s }}.tar
+      - name: Load node image
+        run: docker load -i /kind-images/kind-node-${{ matrix.k8s }}.tar
       - name: Create kind cluster
         uses: helm/kind-action@v1.12.0
         with:
@@ -168,18 +142,3 @@ jobs:
         run: kubectl get pods -n default
       - name: Delete release
         run: helm uninstall my-n8n
-      - name: Save node image to cache
-        run: |
-          docker save kindest/node:${{ matrix.k8s }} -o $HOME/kind-node-${{ matrix.k8s }}.tar
-      - name: Push node image to registry
-        if: steps.kind-cache.outputs.cache-hit != 'true'
-        run: |
-          docker tag kindest/node:${{ matrix.k8s }} ghcr.io/${{ github.repository_owner }}/kind-node:${{ matrix.k8s }}
-          docker push ghcr.io/${{ github.repository_owner }}/kind-node:${{ matrix.k8s }}
-      - name: Upload node image artifact
-        if: steps.kind-cache.outputs.cache-hit != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: kind-node-${{ matrix.k8s }}
-          path: ${{ env.HOME }}/kind-node-${{ matrix.k8s }}.tar
-          if-no-files-found: ignore

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,7 +34,7 @@ jobs:
     if: needs.filter.outputs.n8n == 'true'
     # Use a tagged image to avoid pulling the floating `latest`
     container:
-      image: ghcr.io/${{ github.repository_owner }}/helm-tools:v1
+      image: ghcr.io/${{ github.repository_owner }}/helm-tools:v2
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   render:
     runs-on: ubuntu-latest
-    container: ghcr.io/anyfavors/helm-tools:v1
+    container: ghcr.io/anyfavors/helm-tools:v2
     steps:
       - uses: actions/checkout@v4
       - name: Set Helm version

--- a/README.md
+++ b/README.md
@@ -541,11 +541,11 @@ pre-commit install
 ```
 If you prefer not to install the tooling locally, a Docker image with the
 required Helm utilities is available at
-`ghcr.io/anyfavors/helm-tools:v1`.
+`ghcr.io/anyfavors/helm-tools:v2`.
 For example, run the test script inside the container with:
 
 ```bash
-docker run --rm -it -v $(pwd):/charts ghcr.io/anyfavors/helm-tools:v1 ./scripts/run-tests.sh
+docker run --rm -it -v $(pwd):/charts ghcr.io/anyfavors/helm-tools:v2 ./scripts/run-tests.sh
 ```
 
 Install [Helm](https://helm.sh) first:


### PR DESCRIPTION
## Summary
- add kind node images to helm-tools container
- adjust lint workflow to use the bundled images
- bump helm-tools image references to v2

## Testing
- `pre-commit run --files .github/docker/helm-tools.Dockerfile .github/workflows/lint.yaml .github/workflows/pre-commit.yml .github/workflows/template-comment.yml README.md` *(fails: InvalidManifestError)*

------
https://chatgpt.com/codex/tasks/task_e_685ae46fd538832aa669328c8b741b14