### PR TITLE
Use repository artifact across workflows

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -6,10 +6,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  helm:
+  prepare:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: repo
+          path: ${{ github.workspace }}
+
+  helm:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - name: Get latest Helm version
         id: latest
         run: |
@@ -43,8 +57,11 @@ jobs:
 
   n8n:
     runs-on: ubuntu-latest
+    needs: prepare
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Cache Helm plugins and helm-docs
@@ -100,8 +117,11 @@ jobs:
 
   postgres:
     runs-on: ubuntu-latest
+    needs: prepare
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Cache Helm plugins and helm-docs

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,13 +13,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: repo
+          path: ${{ github.workspace }}
+
   filter:
     runs-on: ubuntu-latest
+    needs: prepare
     outputs:
       n8n: ${{ steps.filter.outputs.n8n }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - id: filter
         uses: dorny/paths-filter@v2
         with:
@@ -32,12 +46,14 @@ jobs:
               - 'n8n/values.yaml'
   lint:
     runs-on: ubuntu-latest
-    needs: filter
+    needs: [prepare, filter]
     if: needs.filter.outputs.n8n == "true"
     # Use tagged helm-tools image
     container: ghcr.io/anyfavors/helm-tools:v2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Verify chart documentation
@@ -72,12 +88,14 @@ jobs:
     runs-on: ubuntu-latest
     # Use tagged helm-tools image
     container: ghcr.io/anyfavors/helm-tools:v2
-    needs: filter
+    needs: [prepare, filter]
     if: needs.filter.outputs.n8n == "true"
     env:
       TRIVY_CACHE_DIR: ${{ env.HOME }}/.cache/trivy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - name: Get chart version
         id: chart
         run: |
@@ -112,14 +130,16 @@ jobs:
     runs-on: ubuntu-latest
     # Use tagged helm-tools image
     container: ghcr.io/anyfavors/helm-tools:v2
-    needs: [filter, lint]
+    needs: [prepare, filter, lint]
     if: needs.filter.outputs.n8n == "true"
     strategy:
       matrix:
         k8s:
           - v1.28.15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - name: Load node image
         run: docker load -i /kind-images/kind-node-${{ matrix.k8s }}.tar
       - name: Create kind cluster

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,14 +11,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  filter:
+  prepare:
     runs-on: ubuntu-latest
-    outputs:
-      n8n: ${{ steps.filter.outputs.n8n }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: repo
+          path: ${{ github.workspace }}
+
+  filter:
+    runs-on: ubuntu-latest
+    needs: prepare
+    outputs:
+      n8n: ${{ steps.filter.outputs.n8n }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - id: filter
         uses: dorny/paths-filter@v2
         with:
@@ -30,15 +42,15 @@ jobs:
 
   pre-commit:
     runs-on: ubuntu-latest
-    needs: filter
+    needs: [prepare, filter]
     if: needs.filter.outputs.n8n == 'true'
     # Use a tagged image to avoid pulling the floating `latest`
     container:
       image: ghcr.io/${{ github.repository_owner }}/helm-tools:v2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
+          name: repo
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Setup Helm tools

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,17 +14,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: repo
+          path: ${{ github.workspace }}
+
   release:
     runs-on: ubuntu-latest
     # Use tagged release-tools image
     container:
       image: ghcr.io/${{ github.repository_owner }}/release-tools:v1
+    needs: prepare
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
-
+          name: repo
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -10,11 +10,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: repo
+          path: ${{ github.workspace }}
+
   render:
     runs-on: ubuntu-latest
     container: ghcr.io/anyfavors/helm-tools:v2
+    needs: prepare
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
       - name: Set Helm version
         run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
       - name: Cache Helm plugins and helm-docs


### PR DESCRIPTION
## Summary
- add a `prepare` job that checks out the repo and uploads it as an artifact
- download the artifact instead of checking out in all other jobs

## Testing
- `./scripts/run-tests.sh` *(fails: helm is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ae69796b4832a90403c8c5ff74c6c