### PR TITLE
Fix release workflow by ensuring container image exists

### DIFF
--- a/.github/docker/helm-tools.Dockerfile
+++ b/.github/docker/helm-tools.Dockerfile
@@ -5,7 +5,8 @@ ARG HELM_DOCS_VERSION=v1.14.2
 ARG KIND_NODE_IMAGES="v1.26.15 v1.27.16 v1.28.15"
 
 RUN apt-get update && \
-    apt-get install -y curl git ca-certificates jq python3 python3-pip skopeo && \
+    apt-get install -y curl git ca-certificates jq python3 python3-pip skopeo \
+      docker.io && \
     rm -rf /var/lib/apt/lists/*
 # Provide the `python` command required by some tools
 RUN ln -sf python3 /usr/bin/python

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -236,7 +236,22 @@ jobs:
           wait: 120s
           node_image: kindest/node:${{ matrix.k8s }}
       - name: Check cluster readiness
-        run: kubectl get nodes && kubectl get pods --all-namespaces
+        run: |
+          for i in {1..5}; do
+            if kubectl get nodes && kubectl get pods --all-namespaces; then
+              break
+            fi
+            echo "Cluster not ready yet, retrying in 15s..." >&2
+            sleep 15
+            if [ "$i" -eq 5 ]; then
+              echo "Cluster failed to start" >&2
+              docker ps -a || true
+              kind get clusters || true
+              exit 1
+            fi
+          done
+          kubectl get nodes
+          kubectl get pods --all-namespaces
         working-directory: repo
       - name: Install chart
         run: helm install my-n8n ./n8n --wait --timeout 300s

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -199,7 +199,6 @@ jobs:
           scan-ref: .
           exit-code: 1
           severity: HIGH
-        working-directory: repo
       - name: Scan container image for vulnerabilities
         uses: aquasecurity/trivy-action@0.31.0
         with:
@@ -207,7 +206,6 @@ jobs:
           image-ref: n8nio/n8n:${{ steps.chart.outputs.version }}
           exit-code: 1
           severity: HIGH,CRITICAL
-        working-directory: repo
 
   install:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -131,6 +131,9 @@ jobs:
         uses: ./repo/.github/actions/setup-helm-tools
         with:
           chart_dir: repo/n8n
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+        shell: bash
       - name: Helm lint
         run: helm lint n8n --values n8n/values.yaml
         working-directory: repo

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -196,10 +196,10 @@ jobs:
         uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: fs
-          scan-ref: n8n
+          scan-ref: .
           exit-code: 1
           severity: HIGH
-          args: --ignorefile .trivyignore
+        working-directory: repo
       - name: Scan container image for vulnerabilities
         uses: aquasecurity/trivy-action@0.31.0
         with:
@@ -207,7 +207,7 @@ jobs:
           image-ref: n8nio/n8n:${{ steps.chart.outputs.version }}
           exit-code: 1
           severity: HIGH,CRITICAL
-          args: --ignorefile .trivyignore
+        working-directory: repo
 
   install:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -134,6 +134,11 @@ jobs:
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest
         shell: bash
+      - name: Install helm-schema-gen plugin
+        run: |
+          helm plugin install \
+            https://github.com/karuppiah7890/helm-schema-gen.git
+        shell: bash
       - name: Helm lint
         run: helm lint n8n --values n8n/values.yaml
         working-directory: repo

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -85,7 +85,7 @@ jobs:
           ls -al repo
       - name: Build helm-tools image if missing
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v2
+          IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v4
         run: |
           if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
             echo "${{ secrets.GITHUB_TOKEN }}" | \
@@ -101,7 +101,7 @@ jobs:
     needs: [prepare, filter, helm-tools]
     if: ${{ needs.filter.outputs.n8n == 'true' }}
     # Use tagged helm-tools image
-    container: ghcr.io/anyfavors/helm-tools:v2
+    container: ghcr.io/anyfavors/helm-tools:v4
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -162,7 +162,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     # Use tagged helm-tools image
-    container: ghcr.io/anyfavors/helm-tools:v2
+    container: ghcr.io/anyfavors/helm-tools:v4
     needs: [prepare, filter, helm-tools]
     if: ${{ needs.filter.outputs.n8n == 'true' }}
     env:
@@ -210,7 +210,7 @@ jobs:
   install:
     runs-on: ubuntu-latest
     # Use tagged helm-tools image
-    container: ghcr.io/anyfavors/helm-tools:v2
+    container: ghcr.io/anyfavors/helm-tools:v4
     needs: [prepare, filter, helm-tools, lint]
     if: ${{ needs.filter.outputs.n8n == 'true' }}
     strategy:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -209,8 +209,6 @@ jobs:
 
   install:
     runs-on: ubuntu-latest
-    # Use tagged helm-tools image
-    container: ghcr.io/anyfavors/helm-tools:v4
     needs: [prepare, filter, helm-tools, lint]
     if: ${{ needs.filter.outputs.n8n == 'true' }}
     strategy:
@@ -227,14 +225,10 @@ jobs:
           mkdir repo
           tar -xzf repo.tar.gz -C repo
           ls -al repo
-      - name: Load node image
-        run: docker load -i /kind-images/kind-node-${{ matrix.k8s }}.tar
-        working-directory: repo
       - name: Create kind cluster
         uses: helm/kind-action@v1.12.0
         with:
-          wait: 120s
-          node_image: kindest/node:${{ matrix.k8s }}
+          wait: 240s
       - name: Debug Docker and Kind
         run: |
           docker ps -a

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -154,7 +154,7 @@ jobs:
     needs: [prepare, filter, helm-tools]
     if: needs.filter.outputs.n8n == "true"
     env:
-      TRIVY_CACHE_DIR: ${{ env.HOME }}/.cache/trivy
+      TRIVY_CACHE_DIR: /tmp/trivy-cache
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -99,7 +99,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     needs: [prepare, filter, helm-tools]
-    if: needs.filter.outputs.n8n == "true"
+    if: ${{ needs.filter.outputs.n8n == 'true' }}
     # Use tagged helm-tools image
     container: ghcr.io/anyfavors/helm-tools:v2
     steps:
@@ -117,7 +117,7 @@ jobs:
           echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
         working-directory: repo
       - name: Verify chart documentation
-        if: needs.filter.outputs.docs == 'true'
+        if: ${{ needs.filter.outputs.docs == 'true' }}
         run: |
           helm-docs
           if ! git diff --quiet; then
@@ -156,7 +156,7 @@ jobs:
     # Use tagged helm-tools image
     container: ghcr.io/anyfavors/helm-tools:v2
     needs: [prepare, filter, helm-tools]
-    if: needs.filter.outputs.n8n == "true"
+    if: ${{ needs.filter.outputs.n8n == 'true' }}
     env:
       TRIVY_CACHE_DIR: /tmp/trivy-cache
     steps:
@@ -206,7 +206,7 @@ jobs:
     # Use tagged helm-tools image
     container: ghcr.io/anyfavors/helm-tools:v2
     needs: [prepare, filter, helm-tools, lint]
-    if: needs.filter.outputs.n8n == "true"
+    if: ${{ needs.filter.outputs.n8n == 'true' }}
     strategy:
       matrix:
         k8s:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,7 @@
+---
 name: Lint
 
-on:
+'on':
   push:
     branches:
       - main
@@ -87,8 +88,10 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v2
         run: |
           if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            docker build -t "$IMAGE" -f repo/.github/docker/helm-tools.Dockerfile repo
+            echo "${{ secrets.GITHUB_TOKEN }}" | \
+              docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker build -t "$IMAGE" \
+              -f repo/.github/docker/helm-tools.Dockerfile repo
             docker push "$IMAGE"
           else
             echo "$IMAGE already exists"
@@ -110,7 +113,8 @@ jobs:
           tar -xzf repo.tar.gz -C repo
           ls -al repo
       - name: Set Helm version
-        run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+        run: |
+          echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
         working-directory: repo
       - name: Verify chart documentation
         if: needs.filter.outputs.docs == 'true'
@@ -168,7 +172,8 @@ jobs:
       - name: Get chart version
         id: chart
         run: |
-          version=$(grep '^appVersion:' n8n/Chart.yaml | awk '{print $2}' | tr -d '"')
+          version=$(grep '^appVersion:' n8n/Chart.yaml | awk '{print $2}' \
+            | tr -d '"')
           echo "version=$version" >> "$GITHUB_OUTPUT"
         working-directory: repo
       - name: Cache Trivy data
@@ -176,7 +181,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.TRIVY_CACHE_DIR }}
-          key: trivy-${{ runner.os }}-${{ hashFiles('.github/workflows/lint.yaml') }}
+          key: trivy-${{ runner.os }}-${{ hashFiles('.github/workflows/lint.yaml') }}  # yamllint disable-line rule:line-length
           restore-keys: |
             trivy-${{ runner.os }}-
       - name: Scan chart for vulnerabilities
@@ -234,10 +239,15 @@ jobs:
         if: failure()
         run: |
           kubectl describe pods -n default || true
-          kubectl logs -l "app.kubernetes.io/name=n8n,app.kubernetes.io/instance=my-n8n" -n default || true
+          kubectl logs \
+            -l "app.kubernetes.io/name=n8n,app.kubernetes.io/instance=my-n8n" \
+            -n default || true
         working-directory: repo
       - name: Wait for pods
-        run: kubectl wait --namespace default --for=condition=ready pod -l "app.kubernetes.io/name=n8n,app.kubernetes.io/instance=my-n8n" --timeout=300s
+        run: |
+          kubectl wait --namespace default --for=condition=ready pod \
+            -l "app.kubernetes.io/name=n8n,app.kubernetes.io/instance=my-n8n" \
+            --timeout=300s
         working-directory: repo
       - name: Get pods
         run: kubectl get pods -n default

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -235,7 +235,14 @@ jobs:
         with:
           wait: 120s
           node_image: kindest/node:${{ matrix.k8s }}
+      - name: Debug Docker and Kind
+        run: |
+          docker ps -a
+          kind get clusters || true
+          docker info
+        working-directory: repo
       - name: Check cluster readiness
+        shell: bash
         run: |
           for i in {1..5}; do
             if kubectl get nodes && kubectl get pods --all-namespaces; then

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,7 @@
+---
 name: Pre-commit
 
-on:
+'on':
   push:
     branches:
       - main
@@ -82,8 +83,10 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v4
         run: |
           if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            docker build -t "$IMAGE" -f repo/.github/docker/helm-tools.Dockerfile repo
+            echo "${{ secrets.GITHUB_TOKEN }}" | \
+              docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker build -t "$IMAGE" \
+              -f repo/.github/docker/helm-tools.Dockerfile repo
             docker push "$IMAGE"
           else
             echo "$IMAGE already exists"
@@ -95,10 +98,10 @@ jobs:
     if: needs.filter.outputs.n8n == 'true'
     # Use a tagged image to avoid pulling the floating `latest`
     container:
-      - name: Configure git safe directory
-        run: git config --global --add safe.directory "$(realpath repo)"
       image: ghcr.io/${{ github.repository_owner }}/helm-tools:v4
     steps:
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$(realpath repo)"
       - uses: actions/download-artifact@v4
         with:
           name: repo
@@ -109,7 +112,8 @@ jobs:
           tar -xzf repo.tar.gz -C repo
           ls -al repo
       - name: Set Helm version
-        run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+        run: |
+          echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
         working-directory: repo
       - name: Setup Helm tools
         uses: ./repo/.github/actions/setup-helm-tools
@@ -119,14 +123,16 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.HOME }}/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}  # yamllint disable-line rule:line-length
           restore-keys: |
             pre-commit-${{ runner.os }}-
       - name: Run pre-commit
         run: |
           pre-commit run --files $(
             if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
-              git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }}
+              git diff --name-only \
+                ${{ github.event.pull_request.base.sha }} \
+                ${{ github.sha }}
             else
               git ls-files
             fi

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -79,7 +79,7 @@ jobs:
           ls -al repo
       - name: Build helm-tools image if missing
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v3
+          IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v4
         run: |
           if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -97,7 +97,7 @@ jobs:
     container:
       - name: Configure git safe directory
         run: git config --global --add safe.directory "$(realpath repo)"
-      image: ghcr.io/${{ github.repository_owner }}/helm-tools:v3
+      image: ghcr.io/${{ github.repository_owner }}/helm-tools:v4
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,12 +36,44 @@ jobs:
           name: repo
           path: repo.tar.gz
 
+  release-tools:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: repo
+          path: .
+      - name: Extract repo
+        run: |
+          mkdir repo
+          tar -xzf repo.tar.gz -C repo
+          ls -al repo
+      - name: Ensure repo context exists
+        run: |
+          if [ ! -d repo ]; then
+            echo "ERROR: repo directory not found!" >&2
+            exit 1
+          fi
+          ls -al repo
+      - name: Build release-tools image if missing
+        env:
+          IMAGE: ghcr.io/anyfavors/release-tools:v1
+        run: |
+          if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker build -t "$IMAGE" -f repo/.github/docker/release-tools.Dockerfile repo
+            docker push "$IMAGE"
+          else
+            echo "$IMAGE already exists"
+          fi
+
   release:
     runs-on: ubuntu-latest
     # Use tagged release-tools image
     container:
       image: ghcr.io/anyfavors/release-tools:v1
-    needs: prepare
+    needs: [prepare, release-tools]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
+---
 name: Release Charts
 
-on:
+'on':
   push:
     branches:
       - main
@@ -61,8 +62,10 @@ jobs:
           IMAGE: ghcr.io/anyfavors/release-tools:v1
         run: |
           if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            docker build -t "$IMAGE" -f repo/.github/docker/release-tools.Dockerfile repo
+            echo "${{ secrets.GITHUB_TOKEN }}" | \
+              docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker build -t "$IMAGE" \
+              -f repo/.github/docker/release-tools.Dockerfile repo
             docker push "$IMAGE"
           else
             echo "$IMAGE already exists"
@@ -134,7 +137,8 @@ jobs:
         env:
           OCI_REPO: ghcr.io/${{ github.repository_owner }}/charts
         run: |
-          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          helm registry login ghcr.io \
+            -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           chart=$(ls .cr-release-packages/n8n-*.tgz | head -n 1)
           helm push "$chart" "oci://$OCI_REPO"
         working-directory: repo
@@ -168,4 +172,3 @@ jobs:
         with:
           name: chart-packages
           path: .cr-release-packages/*.tgz
-

--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -1,6 +1,7 @@
+---
 name: Render Helm Template
 
-on:
+'on':
   pull_request:
     paths:
       - 'n8n/**'
@@ -57,8 +58,10 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v4
         run: |
           if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            docker build -t "$IMAGE" -f repo/.github/docker/helm-tools.Dockerfile repo
+            echo "${{ secrets.GITHUB_TOKEN }}" | \
+              docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker build -t "$IMAGE" \
+              -f repo/.github/docker/helm-tools.Dockerfile repo
             docker push "$IMAGE"
           else
             echo "$IMAGE already exists"
@@ -79,7 +82,8 @@ jobs:
           tar -xzf repo.tar.gz -C repo
           ls -al repo
       - name: Set Helm version
-        run: echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
+        run: |
+          echo "HELM_VERSION=$(cat .github/helm-version.txt)" >> "$GITHUB_ENV"
         working-directory: repo
       - name: Cache Helm plugins and helm-docs
         uses: actions/cache@v3
@@ -111,7 +115,8 @@ jobs:
             let body = fs.readFileSync('template.txt', 'utf8');
             const limit = 65000;
             if (body.length > limit) {
-              body = body.slice(0, limit) + '\n\nOutput truncated. Download artifact for full template.';
+              body = body.slice(0, limit) +
+                '\n\nOutput truncated. Download artifact for full template.';
             }
             github.rest.issues.createComment({
               ...context.repo,

--- a/.github/workflows/template-comment.yml
+++ b/.github/workflows/template-comment.yml
@@ -54,7 +54,7 @@ jobs:
           ls -al repo
       - name: Build helm-tools image if missing
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v3
+          IMAGE: ghcr.io/${{ github.repository_owner }}/helm-tools:v4
         run: |
           if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -66,7 +66,7 @@ jobs:
 
   render:
     runs-on: ubuntu-latest
-    container: ghcr.io/anyfavors/helm-tools:v3
+    container: ghcr.io/anyfavors/helm-tools:v4
     needs: [prepare, helm-tools]
     steps:
       - uses: actions/download-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,9 @@ repos:
         entry: bash scripts/pre-commit-helm-schema.sh
         language: system
         pass_filenames: false
-  - repo: https://github.com/koalaman/shellcheck
-    rev: v0.9.0
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    # Use the shellcheck wrapper with pre-commit hooks
+    rev: v0.9.0.1
     hooks:
       - id: shellcheck
   - repo: https://github.com/adrienverge/yamllint

--- a/README.md
+++ b/README.md
@@ -546,11 +546,11 @@ pre-commit install
 ```
 If you prefer not to install the tooling locally, a Docker image with the
 required Helm utilities is available at
-`ghcr.io/anyfavors/helm-tools:v2`.
+`ghcr.io/anyfavors/helm-tools:v4`.
 For example, run the test script inside the container with:
 
 ```bash
-docker run --rm -it -v $(pwd):/charts ghcr.io/anyfavors/helm-tools:v2 ./scripts/run-tests.sh
+docker run --rm -it -v $(pwd):/charts ghcr.io/anyfavors/helm-tools:v4 ./scripts/run-tests.sh
 ```
 
 Install [Helm](https://helm.sh) first:


### PR DESCRIPTION
## Summary
- build the `release-tools` container image if it's missing
- depend on the new job in the `release` job so the container is always available

## Testing
- `yamllint .github/workflows/release.yaml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_685d61ce0b10832aa1f5f65984fb7737