### PR TITLE
Fix CI path filter errors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -62,6 +62,7 @@ jobs:
             docs:
               - 'n8n/templates/**'
               - 'n8n/values.yaml'
+        working-directory: repo
 
   helm-tools:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -57,6 +57,7 @@ jobs:
               - 'n8n/**'
               - '!n8n/README.md'
               - '!n8n/docs/**'
+        working-directory: repo
 
   helm-tools:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- set `working-directory: repo` for filter steps in CI workflows

## Testing
- `./scripts/run-tests.sh`
- `pre-commit run --files $(git ls-files | tr '\n' ' ')` *(fails: yamllint lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_685f72fb81f4832aa9c531f9e85ad9d1