### PR TITLE
Fix Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,10 +5,9 @@
   ],
   "automerge": true,
   "automergeType": "pr",
-  "deleteBranchAfterMerge": true,
   "packageRules": [
     {
-      "matchManagers": ["helm"],
+      "matchManagers": ["helm-requirements"],
       "matchPackageNames": ["postgresql"],
       "groupName": "bitnami/postgresql"
     },


### PR DESCRIPTION
## Summary
- remove obsolete `deleteBranchAfterMerge` flag
- use `helm-requirements` manager in Renovate rules

## Testing
- `pre-commit run --files .github/renovate.json` *(fails: helm-docs command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7a98bc84832aa14ba82cebe1f77b